### PR TITLE
Fix TinyMCE js error when some of the config values is a function, throwing js TypeError:

### DIFF
--- a/wire/modules/Inputfield/InputfieldTinyMCE/InputfieldTinyMCE.js
+++ b/wire/modules/Inputfield/InputfieldTinyMCE/InputfieldTinyMCE.js
@@ -1,4 +1,3 @@
-
 var InputfieldTinyMCEConfigDefaults = {
 	mode: 'none', 
 	width: "100%", 
@@ -97,7 +96,7 @@ $(document).ready(function() {
 	// this ensures it works with object type of configurations like template_templates:[{title:'mytemplate'},...]
 	function convertObjects(config) {
 		$.each(config, function(key, value) {
-			if(value && value.substr(0, 1) == "[" ) config[key] = eval(value);
+			if(value && value.substr && value.substr(0, 1) == "[" ) config[key] = eval(value);
 		});
 		return config;
 	};


### PR DESCRIPTION
...js TypeError: Object function (ed) { if(ed.isDirty && docheck)... } has no method 'substr'.

I haven't investigated why "config" has functions in his values. The error was rarely found in Chrome and a few times in Firefox in one old and two new projects updated with the latest PW. Probably it is related to children count, I am not sure. I cant make a relation to some beta features like Repeater or multi-language fields either.

EDIT: Just saw that Soma has suggested similar fix for the same issue. Sorry.
