### PR TITLE
Typo fixed: outout > output

### DIFF
--- a/wire/modules/Process/ProcessTemplate/ProcessTemplate.module
+++ b/wire/modules/Process/ProcessTemplate/ProcessTemplate.module
@@ -616,7 +616,7 @@ class ProcessTemplate extends Process {
 
 		$labelGET = $this->_('Cache disabling GET variables');
 		$labelPOST = $this->_('Cache disabling POST variables');
-		$description = $this->_('When your template outout is cached, variables of this type are ignored by default. You can optionally specify one or more variable names that will disable the cache for that request, causing the page to be rendered sans cache.'); // Disable cache, GET/POST vars, description
+		$description = $this->_('When your template output is cached, variables of this type are ignored by default. You can optionally specify one or more variable names that will disable the cache for that request, causing the page to be rendered sans cache.'); // Disable cache, GET/POST vars, description
 		$notes = $this->_('Optionally enter one or more variable names. If entering more than one, separate each by a space.'); // Disable cache, GET/POST vars, notes
 
 		$field = $this->modules->get('InputfieldText'); 


### PR DESCRIPTION
During translation I found this (supposed) typo.
