### PR TITLE
Text fixes

### DIFF
--- a/wire/modules/Process/ProcessTemplate/ProcessTemplate.module
+++ b/wire/modules/Process/ProcessTemplate/ProcessTemplate.module
@@ -657,7 +657,7 @@ class ProcessTemplate extends Process {
 				 if(is_writable($template->filename)) $field->description .= $this->_('The template filename is writable and will be renamed as well.'); // Rename template, filename writable, description
 					else $field->description .= $this->_('The template file is not writable so you will have to rename it manually (instructions will be provided after you save).'); // Rename template, filename not writable, description
 			}
-			$field->notes = $this->_('Enter any combination of letters (a-z), numbers (0-9), dashes or underscores (no spaces). Do not include the .php file extension.'); // Rename template, notes
+			$field->notes = $this->_('Enter any combination of letters (a-z), numbers (0-9), hyphens or underscores (no spaces). Do not include the .php file extension.'); // Rename template, notes
 			$field->attr('id+name', 'rename'); 
 			$field->attr('value', $template->name); 
 			$field->collapsed = Inputfield::collapsedYes;


### PR DESCRIPTION
Two small fixes in the text:
1. outout -> output (probably typo?)
2. dashes changed to hyphens: the character you mentioned in the text is actually not a dash, but a hyphen (or more precisely it's a hyphen-minus). I don't think it's necessary to bother the users with the difference between hyphen and hyphen-minus, but if the only accepted character is hyphen, we should call it hyphen and not a dash. You can check the difference:
http://en.wikipedia.org/wiki/Dash
http://en.wikipedia.org/wiki/Hyphen
http://en.wikipedia.org/wiki/Hyphen-minus
