### PR TITLE
Allow guests to use process modules

### DIFF
--- a/wire/modules/PagePermissions.module
+++ b/wire/modules/PagePermissions.module
@@ -188,7 +188,7 @@ class PagePermissions extends WireData implements Module {
 
 		$user = $this->fuel('user');
 
-		if($user->isGuest()) return false;
+		//if($user->isGuest()) return false;
 		if($user->isSuperuser()) return true; 
 
 		$info = $this->fuel('modules')->getModuleInfo($process); 


### PR DESCRIPTION
Hi Ryan, I've been using processwire for my most recent projects -- really loving it. I'm sending a couple pull requests your way, starting with this one; I had to make changes to core for a couple projects. And I'm wondering if I'm either missing something or these are changes that would be helpful to the community. 

I couldn't figure out why you would want to prohibit guests from accessing process modules, isn't it enough to simply not give them permissions to the admin page? 

I created a couple custom modules that inherited from Process and then found out that guests weren't able to access the corresponding pages. 
