### PR TITLE
Allow unpublished pages to be used when setting/getting pages in FieldtypePage

### DIFF
--- a/wire/modules/Fieldtype/FieldtypePage.module
+++ b/wire/modules/Fieldtype/FieldtypePage.module
@@ -146,7 +146,7 @@ class FieldtypePage extends FieldtypeMulti {
 				$pageArray = $this->fuel('pages')->getById(array((int) reset($value)), $template); 
 				if(count($pageArray)) $pg = $pageArray->first();
 			}
-			if(!$pg || ($pg && $pg->status >= Page::statusUnpublished)) $pg = $this->getBlankValue($page, $field);
+            if(!$pg /*|| ($pg && $pg->status >= Page::statusUnpublished)*/) $pg = $this->getBlankValue($page, $field);
 			return $pg; 
 
 		} else {


### PR DESCRIPTION
I'm creating a workflow process that allows users to submit a page to be published and then an approver will review the submission and schedule the publication. I'm using the page field type to store the page that is being requested for publication, but without this fix, the unpublished page would not get loaded into the select. 
