### PR TITLE
allow accessing variables via input->name

### DIFF
--- a/wire/core/Input.php
+++ b/wire/core/Input.php
@@ -288,6 +288,9 @@ class WireInput {
 		$gpc = array('get', 'post', 'cookie', 'whitelist'); 
 		if(in_array($key, $gpc)) {
 			$value = $this->$key(); 
+        } else {
+            $value = $this->get($key);
+            $value = isset($value) ? $value : $this->post($key);
 		}
 		return $value; 
 	}


### PR DESCRIPTION
The documentation says that you can effectively access $_REQUEST variables via $input->name, but it seems like this bit of code was missing to allow that. 
