### PR TITLE
Update htaccess.txt

### DIFF
--- a/htaccess.txt
+++ b/htaccess.txt
@@ -5,10 +5,13 @@
 
 # -----------------------------------------------------------------------------------------------
 # Don't show directory indexes, but do follow symbolic links 
+# Note: some cloud hosting companies don't allow +FollowSymLinks
+# Uncomment +SymLinksifOwnerMatch and comment +FollowSymLinks if you have troubles
 # -----------------------------------------------------------------------------------------------
 
 Options -Indexes
 Options +FollowSymLinks
+# Options +SymLinksifOwnerMatch
 
 # -----------------------------------------------------------------------------------------------
 # Let ProcessWire handle 404s


### PR DESCRIPTION
Recently alot of cloud hosting companies don't allow +FollowSymLinks because of a security risk in Apache 2.2, 
see: http://serverfault.com/questions/244592/followsymlinks-on-apache-why-is-it-a-security-risk
Uncomment +SymLinksifOwnerMatch and comment +FollowSymLinks if you have troubles
