### PR TITLE
Update InputfieldRepeater.module

### DIFF
--- a/wire/modules/Fieldtype/FieldtypeRepeater/InputfieldRepeater.module
+++ b/wire/modules/Fieldtype/FieldtypeRepeater/InputfieldRepeater.module
@@ -147,8 +147,10 @@ class InputfieldRepeater extends Inputfield {
 			$sort->label = $this->_('Sort');
 			$sort->attr('value', $cnt);
 
-			$wrap = wire('modules')->get('InputfieldFieldset'); 
-			$wrap->label = "$label #" . (++$cnt); 
+			$wrap = wire('modules')->get('InputfieldFieldset');			
+			$wrapTitle = $page->get("title|headline");
+			$wrapTitleGeneric = "$label #" . (++$cnt);			
+			$wrap->label = $wrapTitle ? "$wrapTitle ($wrapTitleGeneric)" : $wrapTitleGeneric;  
 
 			// add a hidden field that will be populated with a positive value for all visible repeater items
 			// this is so that processInput can see this item should be a published item


### PR DESCRIPTION
I find
Repeater-Name #1
Repeater-Name #2
Repeater-Name #n
is too generic and not enough when the wrappers are collapsed
i.e. for sorting purposes

So it looks if there is a title or a headline defined and
prepends it to the generic label.

Maybe you can think of yet another field besides title and headline.
