### PR TITLE
Possible fix: "Error: Call to a member function getLoadQueryAutojoin() on a non-object"

### DIFF
--- a/wire/core/Modules.php
+++ b/wire/core/Modules.php
@@ -289,7 +289,10 @@ class Modules extends WireArray {
 		if($level == 0) {
 			$startPath = $path;
 			$cacheFilename = $config->paths->cache . "Modules." . md5($path) . ".cache";
-			if($readCache && is_file($cacheFilename)) return explode("\n", file_get_contents($cacheFilename)); 
+			if($readCache && is_file($cacheFilename)) {
+				$cacheContents = explode("\n", file_get_contents($cacheFilename));
+				if(!empty($cacheContents)) return $cacheContents;
+			} 
 		}
 
 		$files = array();
@@ -320,7 +323,7 @@ class Modules extends WireArray {
 			$files[] = str_replace($startPath, '', $pathname); 
 		}
 
-		if($level == 0) @file_put_contents($cacheFilename, implode("\n", $files), LOCK_EX); 
+		if($level == 0) @file_put_contents($cacheFilename, implode("\n", $files)); 
 		if($config->chmodFile) @chmod($cacheFilename, octdec($config->chmodFile));
 
 		return $files;


### PR DESCRIPTION
I recently set up ProcessWire on some cloud hosting (from Vidahost), and encountered the same error as [mentioned on the forum](http://processwire.com/talk/topic/2228-trouble-with-install-rackspace-cloudsites/).

I eventually managed to trace the problem back - please bear with me :)
- The "non-object" mentioned in the error was the "type" property (which was NULL) of the fieldtypes list for a template (the loop in Pages.php).
- It was NULL because fieldtype information was not set when initialised.
- ... because the list of modules could not be loaded and returned to the functions relying on them.

I think this was caused by the `findModuleFiles()` function. Although it seemed it could create the file on the first call of this function, the combination of network file system in the cloud hosting (which introduced a delay in file access) and the LOCK_EX parameter meant that the data couldn't actually be written to it.

On next calls to the `findModuleFiles()` function, the cache file "exists", but its empty contents are returned - resulting in the error.

From testing, my proposed change removes the LOCK_EX parameter, which allows the data to be written to the file correctly. In addition, if the cache exists - the content is only returned if the array isn't empty.
