### PR TITLE
Fixed getModuleInfo() syntax error on php older than 5.2.3

### DIFF
--- a/wire/core/Modules.php
+++ b/wire/core/Modules.php
@@ -270,7 +270,8 @@ class Modules extends WireArray {
 				// include the module and instantiate it but don't init() it,
 				// because it will be done by Modules::init()
 				include_once($pathname); 
-				$moduleInfo = $basename::getModuleInfo();
+				//$moduleInfo = $basename::getModuleInfo(); // requires PHP 5.2.3+
+				$moduleInfo = call_user_func(array($basename, 'getModuleInfo'));
 				// if not defined in getModuleInfo, then we'll accept the database flag as enough proof
 				// since the module may have defined it via an isAutoload() function
 				if(!isset($moduleInfo['autoload'])) $moduleInfo['autoload'] = true;


### PR DESCRIPTION
I got following error on php 5.2.14 and 5.2.17 servers:

```
Parse error: syntax error, unexpected T_PAAMAYIM_NEKUDOTAYIM in /Users/Roope/Sites/test/wire/core/Modules.php on line 273
```

Same kind of issue was referenced on line 764 so added similar fix for this one.
