### PR TITLE
Ignore Subversion files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ site-skyscrapers
 tmp
 upgrade.php
 .idea
+.svn


### PR DESCRIPTION
Suggesting addition of .svn to .gitignore file in order to ignore .svn directories. This only applies to users working with Git and Subversion in tandem -- perhaps not _very common_ use case, but (at least from my point of view) common enough to deserve a one row addition :)
