### PR TITLE
Fix incorrect variable name in numChildren

### DIFF
--- a/wire/core/Page.php
+++ b/wire/core/Page.php
@@ -804,7 +804,7 @@ class Page extends WireData {
 	 *
 	 */
 	public function numChildren($onlyVisible = false) {
-		if(!$onlyViewable) return $this->settings['numChildren'];
+		if(!$onlyVisible) return $this->settings['numChildren'];
 		return $this->children('limit=2')->getTotal();
 	}
 


### PR DESCRIPTION
Method numChildren() was getting $onlyVisible as it's param but looked for $onlyViewable, resulting in PHP notice and broken behavior when called with any value evaluating to true.
