### PR TITLE
double-click to edit: check for edit URL before attempting to redirect

### DIFF
--- a/wire/modules/Process/ProcessPageList/ProcessPageList.js
+++ b/wire/modules/Process/ProcessPageList/ProcessPageList.js
@@ -402,7 +402,8 @@ $(document).ready(function() {
 
 				//$("a.PageListPage", $ul).click(clickChild); 
 				$("a.PageListPage", $ul).click(clickChild).dblclick(function() {
-					window.open($(this).siblings('ul').find('li.PageListActionEdit a').attr('href'), "_self");
+					var href = $(this).siblings('ul').find('li.PageListActionEdit a').attr('href');
+					if (href) window.open(href, "_self");
 				});
 				$(".PageListActionMove a", $ul).click(clickMove); 
 				$(".PageListActionSelect a", $ul).click(clickSelect); 


### PR DESCRIPTION
After double-clicking a page without edit link (no edit access) user was redirected to /processwire/page/undefined. An easy fix for this is to check whether edit URL was found before attempting to redirect.
