### PR TITLE
Circular reference mitigation

### DIFF
--- a/wire/core/Page.php
+++ b/wire/core/Page.php
@@ -1546,7 +1546,7 @@ class Page extends WireData implements Countable {
 			foreach($this->template->fieldgroup as $field) {
 				$value = parent::get($field->name);
 				if($value != null && is_object($value)) {
-					if(method_exists($value, 'uncache')) $value->uncache();
+					if(method_exists($value, 'uncache') && $value->id != $this->id) $value->uncache();
 					parent::set($field->name, null); 
 				}
 			}


### PR DESCRIPTION
Hi Ryan, we ran into a series of out of memory errors during page saves after a page was mistakenly self-referenced, e.g. $page->FieldtypePage[Select] = $page. This took care of it, though I'm not certain it's the best place to prevent it.

---

Adding self check to prevent circular reference on page save leading to OOM. This will occur in cases where a Page contains a Page select input, with $this selected. While this would likely be due to a administration mistake or the result of poor template design, it will white-screen any page save containing the field as it attempts to uncache. 
