### PR TITLE
Safe check for existance of $options in PageRender::getCacheFile

### DIFF
--- a/wire/modules/PageRender.module
+++ b/wire/modules/PageRender.module
@@ -145,9 +145,13 @@ class PageRender extends WireData implements Module, ConfigurableModule {
 					$secondaryID .= $this->sanitizer->pageName($urlSegment) . '+';
 				}
 			}
-
-			if($options['prependFile'] || $options['appendFile'] || $options['filename']) {
-				$secondaryID .= md5($options['prependFile'] . '+' . $options['appendFile'] . '+' . $options['filename']) . '+';
+			if(isset($options['prependFile']) || isset($options['appendFile']) || isset($options['filename'])) {
+				$idSuffix = array(
+					isset($options['prependFile']) ? $options['prependFile'] : '',
+					isset($options['appendFile']) ? $options['appendFile'] : '',
+					isset($options['filename']) ? $options['filename'] : '',
+				);
+				$secondaryID .= md5(implode('+', $idSuffix)) . '+';
 			}
 
 			if($pageNum > 1) $secondaryID .= "page{$pageNum}";


### PR DESCRIPTION
If there were no options this produced notices in some cases.
