### PR TITLE
Trigger 'pageMoved' event on moved page list item

### DIFF
--- a/wire/modules/Process/ProcessPageList/ProcessPageList.js
+++ b/wire/modules/Process/ProcessPageList/ProcessPageList.js
@@ -693,6 +693,9 @@ $(document).ready(function() {
 					$root.removeClass('PageListSortSaving'); 
 
 				}, 'json'); 
+				
+				// trigger pageMoved event
+				$li.trigger('pageMoved');
 
 				return true; // whether or not to allow the sort
 			}


### PR DESCRIPTION
While working on a page list module related to Antti's UserGroups module, I realized that I'd have to find a way to catch page move event in page list and update data accordingly, which currently doesn't seem to be possible -- at least not to my knowledge and without rather ugly hacks.

To solve needs like this I'm suggesting addition of one custom event that fires after page has moved. This change is relatively small, but enables module authors working on page list modules to consider page location (parents, siblings, children) in reasonably simple way.
