### PR TITLE
Added enclosure to RSS Markup module

### DIFF
--- a/wire/modules/Markup/MarkupRSS.module
+++ b/wire/modules/Markup/MarkupRSS.module
@@ -36,7 +36,6 @@ class MarkupRSS extends WireData implements Module, ConfigurableModule {
 		'xsl' => '',
 		'css' => '',
 		'copyright' => '',
-		'enclosure' => '', // used for a files, if array specified, the first one is taken.
 		'width' => 400, // if an image is chosen for enclosure
 		'height' => 300, // if an image is chosen for enclosure
 		'boundingbox' => 0, // scale image till one of the edges reach the width or height 
@@ -45,6 +44,8 @@ class MarkupRSS extends WireData implements Module, ConfigurableModule {
 		'itemDescriptionField' => 'summary',
 		'itemDescriptionLength' => 1024,
 		'itemDateField' => 'created',
+		'itemLinkField' => '',
+		'itemEnclosureField' => '', // used for a files, if array specified, the first one is taken.
 		'header' => 'Content-Type: application/xml; charset=utf-8;',
 		'feedPages' => array(),
 		);
@@ -120,6 +121,7 @@ class MarkupRSS extends WireData implements Module, ConfigurableModule {
 		}
 
 		$enclosure = $this->enclosure($page);
+		$link = $this->link($page);
 
 		$description = $page->get($this->itemDescriptionField);
 		if(is_null($description)) $description = '';
@@ -130,7 +132,7 @@ class MarkupRSS extends WireData implements Module, ConfigurableModule {
 			"\t\t<description><![CDATA[$description]]></description>\n" .
 			$enclosure .
 			$pubDate .
-			"\t\t<link>{$page->httpUrl}</link>\n" .
+			$link .
 			"\t\t<guid>{$page->httpUrl}</guid>\n" .
 			"\t</item>\n";
 
@@ -205,18 +207,19 @@ class MarkupRSS extends WireData implements Module, ConfigurableModule {
 		return trim(substr($str, 0, $bestPos+1));
 	}
 
-
 	/**
-	 * Creating the enclosure item tag for file or image. If the enclose is an image rescale the image if needed. 
+	 * Enclosure element of <item> could be a image or file. It has three required attributes. 
+	 * url says where the enclosure is located, length says how big it is in bytes, and type 
+	 * says what its type is, a standard MIME type.
 	 * 
 	 */
 	protected function enclosure(Page $page) {
 
 		$enclosure = '';
 
-		if(!$this->enclosure || !$page->template->hasField($this->enclosure)) return $enclosure;
+		if(!$this->itemEnclosureField || !$page->template->hasField($this->itemEnclosureField)) return $enclosure;
 
-		$string = $this->enclosure;
+		$string = $this->itemEnclosureField;
 		$field = $page->$string;
 		$count = count($field);
 
@@ -228,7 +231,6 @@ class MarkupRSS extends WireData implements Module, ConfigurableModule {
 
 		if($field && strlen($field->filename)) { 
 
-			// requires php 4.3
 			$finfo = finfo_open(FILEINFO_MIME_TYPE);
 			$type = finfo_file($finfo, $field->filename);
 			finfo_close($finfo);
@@ -239,7 +241,6 @@ class MarkupRSS extends WireData implements Module, ConfigurableModule {
 				$height = (int) $this->height;
 
 				if ($width && $height && $this->boundingbox) {
-					
 					$ratiox = $width / $field->width;
 					$ratioy = $height / $field->height;
 					
@@ -247,7 +248,6 @@ class MarkupRSS extends WireData implements Module, ConfigurableModule {
 					$height = min($ratiox, $ratioy) * $field->height;
 
 					$field = $field->size($width, $height);
-					
 				} else if($width || $height) {
 					$field = $field->size($width, $height);
 				}
@@ -259,6 +259,21 @@ class MarkupRSS extends WireData implements Module, ConfigurableModule {
 		return $enclosure;
 	}
 
+	/**
+	 * By default the Page httpUrl is used as link. If itemLinkField is specified, that field is used
+	 * is used for the item link. For the guid item, we stil use the PageUrl. 
+	 * 
+	 */
+	protected function link(Page $page) {
+
+		if(!$this->itemLinkField) return "\t\t<link>{$page->httpUrl}</link>\n";
+		
+		$field = $this->itemLinkField;
+		$url = $this->sanitizer->url($page->$field);
+		
+		if(strlen($url)) return "\t\t<link>{$url}</link>\n";
+
+	}
 
 	/**
 	 * Provide fields for configuring this module
@@ -351,21 +366,30 @@ class MarkupRSS extends WireData implements Module, ConfigurableModule {
 		$f3->addOption('modified');
 
 		$f4 = wire('modules')->get('InputfieldSelect');
-		$f4->attr('name', 'enclosure');
-		$f4->attr('value', $data['enclosure']);
-		$f4->label = "Default Feed Item File Field (enclosure)";
-		$f4->description = "The default field to use as an individual feed item's enclosure . (If the field contains an array of Pagesfiles, the first one will be used.)";
-		$f4->notes = "The image or file is added to item enclosure tag. Image sizing only occurs if the field is an instance of Pageimage.";
+		$f4->attr('name', 'itemLinkField');
+		$f4->attr('value', $data['itemLinkField']);
+		$f4->label = "Default Feed Item Link Field";
+		$f4->description = "The field to use as an individual feed item's link. Leave blank to use the de Page as link.";
+
+		$f5 = wire('modules')->get('InputfieldSelect');
+		$f5->attr('name', 'itemEnclosureField');
+		$f5->attr('value', $data['itemEnclosureField']);
+		$f5->label = "Default Feed Item File Field (enclosure)";
+		$f5->description = "The default field to use as an individual feed item's enclosure . (If the field contains an array of Pagesfiles, the first one will be used.)";
+		$f5->notes = "The image or file is added to item enclosure tag. Image sizing only occurs if the field is an instance of Pageimage.";
 
 		foreach(wire('fields') as $field) {
 
-			if($field->type instanceof FieldtypeText) {
+			// FieldtypeURL needs to be called before FieldtypeText
+			if($field->type instanceof FieldtypeURL) {
+				$f4->addOption($field->name);
+			} else if($field->type instanceof FieldtypeText) {
 				$f1->addOption($field->name);
 				$f2->addOption($field->name);
 			} else if($field->type instanceof FieldtypeDate) {
 				$f3->addOption($field->name);
 			} else if($field->type instanceof FieldtypeFile) {
-				$f4->addOption($field->name);
+				$f5->addOption($field->name);
 			}
 		}
 
@@ -374,6 +398,7 @@ class MarkupRSS extends WireData implements Module, ConfigurableModule {
 		$inputfields->add($f2a);
 		$inputfields->add($f3);
 		$inputfields->add($f4);
+		$inputfields->add($f5);
 
 		$f = wire('modules')->get('InputfieldInteger');
 		$f->attr('name', 'width');
@@ -400,6 +425,5 @@ class MarkupRSS extends WireData implements Module, ConfigurableModule {
 		$inputfields->add($f);
 
 		return $inputfields;
-
 	}
 }

--- a/wire/modules/Markup/MarkupRSS.module
+++ b/wire/modules/Markup/MarkupRSS.module
@@ -122,6 +122,7 @@ class MarkupRSS extends WireData implements Module, ConfigurableModule {
 
 		$enclosure = $this->enclosure($page);
 		$link = $this->link($page);
+		$guid = $this->link($page, 'guid');
 
 		$description = $page->get($this->itemDescriptionField);
 		if(is_null($description)) $description = '';
@@ -133,7 +134,7 @@ class MarkupRSS extends WireData implements Module, ConfigurableModule {
 			$enclosure .
 			$pubDate .
 			$link .
-			"\t\t<guid>{$page->httpUrl}</guid>\n" .
+			$guid .
 			"\t</item>\n";
 
 		return $out;
@@ -152,9 +153,9 @@ class MarkupRSS extends WireData implements Module, ConfigurableModule {
 		foreach($this->feedPages as $page) {
 			if(!$page->viewable()) continue;
 			$out .= $this->renderItem($page);
-				}
+		}
 
-				$out .= "</channel>\n</rss>\n";
+		$out .= "</channel>\n</rss>\n";
 
 		return $out;
 	}
@@ -264,15 +265,16 @@ class MarkupRSS extends WireData implements Module, ConfigurableModule {
 	 * is used for the item link. For the guid item, we stil use the PageUrl. 
 	 * 
 	 */
-	protected function link(Page $page) {
+	protected function link(Page $page, $tag = 'link') {
 
-		if(!$this->itemLinkField) return "\t\t<link>{$page->httpUrl}</link>\n";
+		if(!$this->itemLinkField) return "\t\t<{$tag}>{$page->httpUrl}</{$tag}>\n";
 		
 		$field = $this->itemLinkField;
 		$url = $this->sanitizer->url($page->$field);
 		
-		if(strlen($url)) return "\t\t<link>{$url}</link>\n";
-
+		if(strlen($url)) return "\t\t<{$tag}>{$url}</{$tag}>\n";
+		
+		return '';
 	}
 
 	/**

--- a/wire/modules/Markup/MarkupRSS.module
+++ b/wire/modules/Markup/MarkupRSS.module
@@ -3,25 +3,25 @@
 /**
  * ProcessWire Markup RSS Module
  *
- * Given a PageArray of pages, this module will render an RSS feed from them. 
+ * Given a PageArray of pages, this module will render an RSS feed from them.
  * This is intended to be used directly from a template file. See usage below.
  *
  * USAGE
  * -----
- * $rss = $modules->get("MarkupRSS"); 
+ * $rss = $modules->get("MarkupRSS");
  * $rss->title = "Latest updates";
- * $rss->description = "The most recent pages updated on my site"; 
+ * $rss->description = "The most recent pages updated on my site";
  * $items = $pages->find("limit=10, sort=-modified"); // or any pages you want
- * $rss->render($items); 
+ * $rss->render($items);
  *
  * See also the $defaultConfigData below (first thing in the class) to see what
- * options you can change at runtime. 
+ * options you can change at runtime.
  *
- * 
- * ProcessWire 2.x 
- * Copyright (C) 2011 by Ryan Cramer 
+ *
+ * ProcessWire 2.x
+ * Copyright (C) 2011 by Ryan Cramer
  * Licensed under GNU/GPL v2, see LICENSE.TXT
- * 
+ *
  * http://www.processwire.com
  * http://www.ryancramer.com
  *
@@ -31,19 +31,23 @@ class MarkupRSS extends WireData implements Module, ConfigurableModule {
 
 	protected static $defaultConfigData = array(
 		'title' => 'Untitled RSS Feed',
-		'url' => '', 
-		'description' => '', 
-		'xsl' => '', 
+		'url' => '',
+		'description' => '',
+		'xsl' => '',
 		'css' => '',
 		'copyright' => '',
+		'enclosure' => '', // used for a files, if array specified, the first one is taken.
+		'width' => 400, // if an image is chosen for enclosure
+		'height' => 300, // if an image is chosen for enclosure
+		'boundingbox' => 0, // scale image till one of the edges reach the width or height 
 		'ttl' => 60,
 		'itemTitleField' => 'title',
 		'itemDescriptionField' => 'summary',
-		'itemDescriptionLength' => 1024, 
+		'itemDescriptionLength' => 1024,
 		'itemDateField' => 'created',
 		'header' => 'Content-Type: application/xml; charset=utf-8;',
-		'feedPages' => array(), 
-		); 
+		'feedPages' => array(),
+		);
 
 	/**
 	 * Return general info about the module for ProcessWire
@@ -51,12 +55,12 @@ class MarkupRSS extends WireData implements Module, ConfigurableModule {
 	 */
 	public static function getModuleInfo() {
 		return array(
-			'title' => 'Markup RSS Feed', 
-			'version' => 100, 
+			'title' => 'Markup RSS Feed',
+			'version' => 101,
 			'summary' => 'Renders an RSS feed. Given a PageArray, renders an RSS feed of them.',
-			'permanent' => false, 
-			'singular' => false, 
-			'autoload' => false, 
+			'permanent' => false,
+			'singular' => false,
+			'autoload' => false,
 			);
 	}
 
@@ -66,7 +70,7 @@ class MarkupRSS extends WireData implements Module, ConfigurableModule {
 	 */
 	public function __construct() {
 		foreach(self::$defaultConfigData as $key => $value) {
-			$this->set($key, $value); 
+			$this->set($key, $value);
 		}
 	}
 
@@ -82,24 +86,22 @@ class MarkupRSS extends WireData implements Module, ConfigurableModule {
 	 */
 	protected function renderHeader() {
 
-                $out = "<?xml version='1.0' encoding='utf-8' ?>\n";
+		$out = "<?xml version='1.0' encoding='UTF-8'?>\n";
+		if($this->xsl) $out .= "<?xml-stylesheet type='text/xsl' href='{$this->xsl}' ?>\n";
+		if($this->css) $out .= "<?xml-stylesheet type='text/css' href='{$this->css}' ?>\n";
 
-                if($this->xsl) $out .= "<?xml-stylesheet type='text/xsl' href='{$this->xsl}' ?>\n";
-                if($this->css) $out .= "<?xml-stylesheet type='text/css' href='{$this->css}' ?>\n";
-		
 		if(!$this->url) $this->url = $this->page->httpUrl;
 
-                $out .= "<rss version='2.0'>\n" .
-                        "<channel>\n" .
-                        "\t<title>{$this->title}</title>\n" . 
-			"\t<link>{$this->url}</link>\n" . 
-			"\t<description>{$this->description}</description>\n" . 
-			"\t<pubDate>" . date(DATE_RFC2822) . "</pubDate>\n";
+			$out .= "<rss version='2.0'>\n" .
+				"<channel>\n" .
+					"\t<title>{$this->title}</title>\n" .
+					"\t<link>{$this->url}</link>\n" .
+					"\t<description>{$this->description}</description>\n" .
+					"\t<pubDate>" . date(DATE_RSS) . "</pubDate>\n";
+				if($this->copyright) $out .= "\t<copyright>{$this->copyright}</copyright>\n";
+				if($this->ttl) $out .= "\t<ttl>{$this->ttl}</ttl>\n";
 
-                if($this->copyright) $out .= "\t<copyright>{$this->copyright}</copyright>\n";
-                if($this->ttl) $out .= "\t<ttl>{$this->ttl}</ttl>\n";
-
-		return $out; 
+		return $out;
 	}
 
 	/**
@@ -112,24 +114,27 @@ class MarkupRSS extends WireData implements Module, ConfigurableModule {
 		if(empty($title)) return '';
 
 		if($this->itemDateField && ($ts = $page->getUnformatted($this->itemDateField))) {
-			$pubDate = "\t\t<pubDate>" . date(DATE_RFC2822, $ts) . "</pubDate>\n";
+			$pubDate = "\t\t<pubDate>" . date(DATE_RSS, $ts) . "</pubDate>\n";
 		} else {
 			$pubDate = '';
 		}
 
-		$description = $page->get($this->itemDescriptionField); 
+		$enclosure = $this->enclosure($page);
+
+		$description = $page->get($this->itemDescriptionField);
 		if(is_null($description)) $description = '';
-		$description = $this->truncateDescription(trim($description)); 
+		$description = $this->truncateDescription(trim($description));
 
 		$out = 	"\t<item>\n" .
 			"\t\t<title>$title</title>\n" .
 			"\t\t<description><![CDATA[$description]]></description>\n" .
+			$enclosure .
 			$pubDate .
 			"\t\t<link>{$page->httpUrl}</link>\n" .
-			"\n\t<guid>{$page->httpUrl}</guid>\n" . 
+			"\t\t<guid>{$page->httpUrl}</guid>\n" .
 			"\t</item>\n";
 
-		return $out; 
+		return $out;
 	}
 
 	/**
@@ -145,11 +150,11 @@ class MarkupRSS extends WireData implements Module, ConfigurableModule {
 		foreach($this->feedPages as $page) {
 			if(!$page->viewable()) continue;
 			$out .= $this->renderItem($page);
-                }
+				}
 
-                $out .= "</channel>\n</rss>\n";
+				$out .= "</channel>\n</rss>\n";
 
-		return $out; 
+		return $out;
 	}
 
 	/**
@@ -157,9 +162,9 @@ class MarkupRSS extends WireData implements Module, ConfigurableModule {
 	 *
 	 */
 	public function render(PageArray $feedPages = null) {
-		header($this->header); 
+		header($this->header);
 		echo $this->renderFeed($feedPages);
-		return true; 
+		return true;
 	}
 
 	/**
@@ -172,11 +177,11 @@ class MarkupRSS extends WireData implements Module, ConfigurableModule {
 		if(!$maxlen) return $str;
 
 		// note: tags are not stripped if itemDescriptionLength == 0
-		$str = strip_tags($str); 
+		$str = strip_tags($str);
 
-		if(strlen($str) < $maxlen) return $str; 
+		if(strlen($str) < $maxlen) return $str;
 
-		$str = trim(substr($str, 0, $maxlen)); 
+		$str = trim(substr($str, 0, $maxlen));
 
 		// boundaries that we can end the summary with
 		$boundaries = array('. ', '? ', '! ', ', ', '; ', '-');
@@ -190,15 +195,70 @@ class MarkupRSS extends WireData implements Module, ConfigurableModule {
 		}
 
 		// determine if we should truncate to last punctuation or last space.
-		// if the last punctuation is further away then 1/4th the total length, then we'll 
+		// if the last punctuation is further away then 1/4th the total length, then we'll
 		// truncate to the last space. Otherwise, we'll truncate to the last punctuation.
-		$spacePos = strrpos($str, ' '); 
-		if($spacePos > $bestPos && (($spacePos - ($maxlen / 4)) > $bestPos)) $bestPos = $spacePos; 
+		$spacePos = strrpos($str, ' ');
+		if($spacePos > $bestPos && (($spacePos - ($maxlen / 4)) > $bestPos)) $bestPos = $spacePos;
 
 		if(!$bestPos) $bestPos = $maxlen;
 
-		return trim(substr($str, 0, $bestPos+1)); 
+		return trim(substr($str, 0, $bestPos+1));
 	}
+
+
+	/**
+	 * Creating the enclosure item tag for file or image. If the enclose is an image rescale the image if needed. 
+	 * 
+	 */
+	protected function enclosure(Page $page) {
+
+		$enclosure = '';
+
+		if(!$this->enclosure || !$page->template->hasField($this->enclosure)) return $enclosure;
+
+		$string = $this->enclosure;
+		$field = $page->$string;
+		$count = count($field);
+
+		if($count === 0) {
+			$field = Null;
+		} else if ($count > 1) {
+			$field = $field->first();
+		}
+
+		if($field && strlen($field->filename)) { 
+
+			// requires php 4.3
+			$finfo = finfo_open(FILEINFO_MIME_TYPE);
+			$type = finfo_file($finfo, $field->filename);
+			finfo_close($finfo);
+
+			if($field instanceof Pageimage) {
+
+				$width = (int) $this->width;
+				$height = (int) $this->height;
+
+				if ($width && $height && $this->boundingbox) {
+					
+					$ratiox = $width / $field->width;
+					$ratioy = $height / $field->height;
+					
+					$width = min($ratiox, $ratioy) * $field->width;
+					$height = min($ratiox, $ratioy) * $field->height;
+
+					$field = $field->size($width, $height);
+					
+				} else if($width || $height) {
+					$field = $field->size($width, $height);
+				}
+			}
+
+			$enclosure = "\t\t<enclosure url='{$field->httpUrl}' length='{$field->filesize}' type='$type' />\n";				
+		}
+		
+		return $enclosure;
+	}
+
 
 	/**
 	 * Provide fields for configuring this module
@@ -207,13 +267,13 @@ class MarkupRSS extends WireData implements Module, ConfigurableModule {
 	static public function getModuleConfigInputfields(array $data) {
 
 		$inputfields = new InputfieldWrapper();
-		$inputfields->description = 
-			"Select the default options for any given feed. Each of these may be overridden in the API, " . 
-			"so the options you select below should be considered defaults, unless you only have 1 feed. " . 
+		$inputfields->description =
+			"Select the default options for any given feed. Each of these may be overridden in the API, " .
+			"so the options you select below should be considered defaults, unless you only have 1 feed. " .
 			"If you only need to support 1 feed, then you will not need to override any of these in the API.";
 
 		foreach(self::$defaultConfigData as $key => $value) {
-			if(!isset($data[$key])) $data[$key] = $value; 
+			if(!isset($data[$key])) $data[$key] = $value;
 		}
 
 		$f = wire('modules')->get('InputfieldText');
@@ -287,17 +347,25 @@ class MarkupRSS extends WireData implements Module, ConfigurableModule {
 		$f3->attr('value', $data['itemDateField']);
 		$f3->label = "Default Feed Item Date Field";
 		$f3->description = "The default field to use as an individual feed item's date.";
-		$f3->addOption('created'); 
+		$f3->addOption('created');
 		$f3->addOption('modified');
+
+		$f4 = wire('modules')->get('InputfieldSelect');
+		$f4->attr('name', 'enclosure');
+		$f4->attr('value', $data['enclosure']);
+		$f4->label = "Default Feed Item File Field (enclosure)";
+		$f4->description = "The default field to use as an individual feed item's enclosure . (If the field contains an array of Pagesfiles, the first one will be used.)";
+		$f4->notes = "The image or file is added to item enclosure tag. Image sizing only occurs if the field is an instance of Pageimage.";
 
 		foreach(wire('fields') as $field) {
 
 			if($field->type instanceof FieldtypeText) {
-				$f1->addOption($field->name); 
-				$f2->addOption($field->name); 
-
+				$f1->addOption($field->name);
+				$f2->addOption($field->name);
 			} else if($field->type instanceof FieldtypeDate) {
-				$f3->addOption($field->name); 
+				$f3->addOption($field->name);
+			} else if($field->type instanceof FieldtypeFile) {
+				$f4->addOption($field->name);
 			}
 		}
 
@@ -305,11 +373,33 @@ class MarkupRSS extends WireData implements Module, ConfigurableModule {
 		$inputfields->add($f2);
 		$inputfields->add($f2a);
 		$inputfields->add($f3);
+		$inputfields->add($f4);
+
+		$f = wire('modules')->get('InputfieldInteger');
+		$f->attr('name', 'width');
+		$f->attr('value', (int) $data['width']);
+		$f->label = "Default width for image enclosure";
+		$f->description = "The width of the image if the enclosure is an image.";
+		$f->notes = "Set 0 for proportional to width.";
+		$inputfields->add($f);
+
+		$f = wire('modules')->get('InputfieldInteger');
+		$f->attr('name', 'height');
+		$f->attr('value', (int) $data['height']);
+		$f->label = "Default height for image enclosure";
+		$f->description = "The width of the image if the enclosure is an image.";
+		$f->notes = "Set 0 for proportional to height.";
+		$inputfields->add($f);
+
+		$f = wire('modules')->get('InputfieldCheckbox');
+		$f->attr('name', 'boundingbox');
+		$f->attr('value', 1);
+		$f->attr('checked', (int) $data['boundingbox'] ? 'checked' : null );
+		$f->label = "Bounding box";
+		$f->description = "Scale the image until one side reaches the goal dimension, specified by width and height. ";
+		$inputfields->add($f);
 
 		return $inputfields;
 
 	}
-
 }
-
-


### PR DESCRIPTION
Hi Ryan,

This update add the possibility to add an enclosure to the RSS Markup generation. For the enclosure an image or a file field can be used. If the field for the enclosure is an image, the image can be scaled to preferred height & width.

If the checkbox Bounding box is checked the images will scale until one side reaches the goal dimension. Specified by width and height, useful for logo's.

Other fixes:
- changed uft to UTF in the xml header - W3c recomendation
- changed the dates to date(DATE_RSS) - W3c recomendation
- updated the version with 1

Thanks,
Martijn