### PR TITLE
fix url segments for nested pages in admin

### DIFF
--- a/wire/modules/LanguageSupport/LanguageSupportPageNames.module
+++ b/wire/modules/LanguageSupport/LanguageSupportPageNames.module
@@ -351,7 +351,7 @@ class LanguageSupportPageNames extends WireData implements Module, ConfigurableM
 		$name = $page->get("name$language|name"); 
 		$path = strlen($name) ? "$path/$name/" : "$path/";
 		
-		if(!$page->template->slashUrls && $path != '/') $path = rtrim($path, '/'); 
+		if(!$this->page->template == 'admin' && !$page->template->slashUrls && $path != '/') $path = rtrim($path, '/'); 
 		
 		return $path;
 	}


### PR DESCRIPTION
Please check if this is the correct/best solution, i'm new at pw.

Problem:
multilang support with page names installed
admin > Pages

Settings tab

english
/en/aboutwhat

...same for other languages
