### PR TITLE
fix for multilang homepage urls

### DIFF
--- a/wire/modules/LanguageSupport/LanguageSupportPageNames.module
+++ b/wire/modules/LanguageSupport/LanguageSupportPageNames.module
@@ -331,8 +331,8 @@ class LanguageSupportPageNames extends WireData implements Module, ConfigurableM
 			// special case: homepage
 			$name = $isDefault ? '' : $page->get("name$language"); 
 			if($isDefault && $this->useHomeSegment) $name = $page->name;
-			if($name == self::HOME_NAME_DEFAULT || !strlen($name)) return '/';
-			return "/$name/";
+			if($name == self::HOME_NAME_DEFAULT || !strlen($name)) return $page->template->slashUrls ? '/' : '';
+			return $page->template->slashUrls ? "/$name/" : "/$name";
 		}
 
 		$path = '';


### PR DESCRIPTION
if homepage tpls have slashUrls disabled, links in navigation should hav href(s) like:

site.tld/it
site.tld/fr
site.tld/es

instead of

site.tld/it/
site.tld/fr/
site.tld/es/

Should we leave the slash for the default language homepage (line 334)
