### PR TITLE
fixes for disabled slashUrls + multilang

### DIFF
--- a/wire/modules/LanguageSupport/LanguageSupportPageNames.module
+++ b/wire/modules/LanguageSupport/LanguageSupportPageNames.module
@@ -331,8 +331,10 @@ class LanguageSupportPageNames extends WireData implements Module, ConfigurableM
 			// special case: homepage
 			$name = $isDefault ? '' : $page->get("name$language"); 
 			if($isDefault && $this->useHomeSegment) $name = $page->name;
-			if($name == self::HOME_NAME_DEFAULT || !strlen($name)) return '/';
-			return "/$name/";
+			if($name == self::HOME_NAME_DEFAULT || !strlen($name)) {
+				return ($page->template->slashUrls || wire('page')->template == 'admin') ? '/' :
+			}
+			return ($page->template->slashUrls || wire('page')->template == 'admin') ? "/$name/" : "/$name";;
 		}
 
 		$path = '';
@@ -351,7 +353,9 @@ class LanguageSupportPageNames extends WireData implements Module, ConfigurableM
 		$name = $page->get("name$language|name"); 
 		$path = strlen($name) ? "$path/$name/" : "$path/";
 		
-		if(!$page->template->slashUrls && $path != '/') $path = rtrim($path, '/'); 
+		if((wire('page')->template != 'admin') && !$page->template->slashUrls && $path != '/') {
+			$path = rtrim($path, '/');
+		}
 		
 		return $path;
 	}


### PR DESCRIPTION
Please check if this is the correct/best solution, i'm new at pw.

Problem 1:
multilang support with page names installed and slashUrls disabled

> admin > Pages >Settings tab

english
/en/aboutwhat

...same for other languages

fix: line 356 if we are in admin do not strip the trailing slash 

Problem2:
if homepage tpls have slashUrls disabled, links in navigation should have href(s) like:

site.tld/it
site.tld/fr
site.tld/es

instead of

site.tld/it/
site.tld/fr/
site.tld/es/

fix lines-335-337
BTW, should we leave the slash for the default language homepage (line 335)

kind regards
