### PR TITLE
InputfieldPage multilang quick add support

### DIFF
--- a/wire/modules/Inputfield/InputfieldPage/InputfieldPage.module
+++ b/wire/modules/Inputfield/InputfieldPage/InputfieldPage.module
@@ -504,6 +504,22 @@ class InputfieldPage extends Inputfield implements ConfigurableModule {
 			$page->sort = $sort++;
 			$page->id = -1; // prevents the permissions check from failing
 
+			if(wire('modules')->isInstalled("LanguageSupport")) {
+                $titleField = $page->fields->get('title');
+
+                if ($titleField && $titleField->type instanceof FieldtypePageTitleLanguage) {
+                    $currentLanguage = wire('user')->language;
+                    foreach (wire('languages') as $language) {
+                        wire('user')->language = $language;
+                        $page->title = trim($title);
+                    }
+                    wire('user')->language = $currentLanguage;
+                }
+                if(wire('modules')->isInstalled("LanguageSupportPageNames")) {
+                    $page->name = $this->sanitizer->pageName(trim($title));
+                }
+            }
+            
 			// on first iteration perform a page-context access check
 			if(!$n && (!$parent->addable($page) || !$page->publishable())) {
 				$this->error("No access to add {$page->template} pages to {$parent->path}"); 

--- a/wire/modules/Inputfield/InputfieldPage/InputfieldPage.module
+++ b/wire/modules/Inputfield/InputfieldPage/InputfieldPage.module
@@ -504,7 +504,7 @@ class InputfieldPage extends Inputfield implements ConfigurableModule {
 			$page->sort = $sort++;
 			$page->id = -1; // prevents the permissions check from failing
 
-			if(wire('modules')->isInstalled("LanguageSupport")) {
+            if(wire('modules')->isInstalled("LanguageSupport")) {
                 $titleField = $page->fields->get('title');
 
                 if ($titleField && $titleField->type instanceof FieldtypePageTitleLanguage) {
@@ -515,11 +515,11 @@ class InputfieldPage extends Inputfield implements ConfigurableModule {
                     }
                     wire('user')->language = $currentLanguage;
                 }
-                if(wire('modules')->isInstalled("LanguageSupportPageNames")) {
+                if (wire('modules')->isInstalled("LanguageSupportPageNames")) {
                     $page->name = $this->sanitizer->pageName(trim($title));
                 }
             }
-            
+
 			// on first iteration perform a page-context access check
 			if(!$n && (!$parent->addable($page) || !$page->publishable())) {
 				$this->error("No access to add {$page->template} pages to {$parent->path}"); 

--- a/wire/modules/Inputfield/InputfieldPage/InputfieldPage.module
+++ b/wire/modules/Inputfield/InputfieldPage/InputfieldPage.module
@@ -504,21 +504,21 @@ class InputfieldPage extends Inputfield implements ConfigurableModule {
 			$page->sort = $sort++;
 			$page->id = -1; // prevents the permissions check from failing
 
-            if(wire('modules')->isInstalled("LanguageSupport")) {
-                $titleField = $page->fields->get('title');
+			if(wire('modules')->isInstalled("LanguageSupport")) {
+				$titleField = $page->fields->get('title');
 
-                if ($titleField && $titleField->type instanceof FieldtypePageTitleLanguage) {
-                    $currentLanguage = wire('user')->language;
-                    foreach (wire('languages') as $language) {
-                        wire('user')->language = $language;
-                        $page->title = trim($title);
-                    }
-                    wire('user')->language = $currentLanguage;
-                }
-                if (wire('modules')->isInstalled("LanguageSupportPageNames")) {
-                    $page->name = $this->sanitizer->pageName(trim($title));
-                }
-            }
+				if ($titleField && $titleField->type instanceof FieldtypePageTitleLanguage) {
+					$currentLanguage = wire('user')->language;
+					foreach (wire('languages') as $language) {
+						wire('user')->language = $language;
+						$page->title = trim($title);
+					}
+					wire('user')->language = $currentLanguage;
+				}
+				if (wire('modules')->isInstalled("LanguageSupportPageNames")) {
+					$page->name = $this->sanitizer->pageName(trim($title));
+				}
+			}
 
 			// on first iteration perform a page-context access check
 			if(!$n && (!$parent->addable($page) || !$page->publishable())) {


### PR DESCRIPTION
Add support for Allow new pages to be created from field options when LanguageSupport, LanguageSupportPageNames and optionally the title field is a FieldtypePageTitleLanguage.
Otherwise new pages canot be saved (empty 'name' exception).

New Pages (most probably tags) will be added with the same title and pageName for all the languages
