### PR TITLE
corrected an issue with autorotation

### DIFF
--- a/wire/core/ImageSizer.php
+++ b/wire/core/ImageSizer.php
@@ -251,9 +251,6 @@ class ImageSizer extends Wire {
 			$image = $this->imRotate($image, $orientations[0]);
 			if($orientations[0] == 90 || $orientations[0] == 270) {
 				// we have to swap width & height now!
-				$tmp = array($targetWidth, $targetHeight);
-				$targetWidth = $tmp[1];
-				$targetHeight = $tmp[0];
 				$tmp = array($this->getWidth(), $this->getHeight());
 				$this->setImageInfo($tmp[1], $tmp[0]);
 			}


### PR DESCRIPTION
Interrobang has found the issue and described it in the forum: http://processwire.com/talk/topic/3278-core-imagemanipulation/page-2#entry55898
It was wrong to swap the targetdimensions too. We only need to adjust the imagedimensions after a rotation of 90 or 270 degree.
