### PR TITLE
Update ProcessHome.module

### DIFF
--- a/wire/modules/Process/ProcessHome.module
+++ b/wire/modules/Process/ProcessHome.module
@@ -31,7 +31,7 @@ class ProcessHome extends Process {
 	}
 
 	public function ___execute() {
-		$this->session->redirect("page/"); 
+		$this->session->redirect($this->page->child->url);
 	}	
 
 }


### PR DESCRIPTION
Just wondering if we can make this change as per this thread: http://processwire.com/talk/topic/3475-default-admin-page/

I can't see that it's broken anything on 2.4 after some testing. I know diogo's module resolves it, but it would be easier (and apparently harmless) to have the change there by default for rolling out custom dashboard modules without the need for the other module.

I suppose custom dashboard modules could require diogo's module, but that seems a bit much to me for the sake of one line of code :)
