### PR TITLE
Update AdminThemeDefault.module

### DIFF
--- a/wire/modules/AdminTheme/AdminThemeDefault/AdminThemeDefault.module
+++ b/wire/modules/AdminTheme/AdminThemeDefault/AdminThemeDefault.module
@@ -14,7 +14,13 @@ class AdminThemeDefault extends AdminTheme implements Module, ConfigurableModule
 	public function init() {
 		parent::init(); 
 		if($this->isCurrent()) {
-			// this is the current admin theme
+			$customStyleFolder = wire('config')->urls->templates . 'AdminThemeDefault';
+			$styleFile = ($this->colors ? 'main-' . $this->colors : 'main') . '.css';
+			if (file_exists(wire('config')->paths->modules . 'AdminTheme/' . __CLASS__ . '/styles/' . $styleFile)) {
+				$this->page->stylesheet = wire('config')->urls->modules . 'AdminTheme/' . __CLASS__ . '/styles/' . $styleFile;
+			} elseif (file_exists(wire('config')->paths->templates . __CLASS__ . '/' . $styleFile)) {
+				$this->page->stylesheet = wire('config')->urls->templates . __CLASS__ . '/' . $styleFile;
+			}
 		}
 	}
 
@@ -31,6 +37,18 @@ class AdminThemeDefault extends AdminTheme implements Module, ConfigurableModule
 		$field->addOption('warm', __('Warm'));
 		$field->addOption('modern', __('Modern'));
 		$field->addOption('futura', __('Futura'));
+
+		// Add custom stylesheets from /site/template/AdminThemeDefault folder
+		$customStyleDir = wire('config')->paths->templates . 'AdminThemeDefault';
+		if (file_exists($customStyleDir)) {
+			foreach (new DirectoryIterator($customStyleDir) as $fileInfo) {
+				if($fileInfo->isDot() || $fileInfo->getExtension() != 'css') continue;
+				$fileName = str_replace('main-', '', $fileInfo->getBasename('.css'));
+				$prettyName = ucwords(str_replace('-', ' ', $fileName));
+				$field->addOption($fileName, __($prettyName));
+			}
+		}
+		
 		$field->attr('value', isset($data['colors']) ? $data['colors'] : ''); 
 		$field->optionColumns = 1; 
 		$inputfields->add($field); 		


### PR DESCRIPTION
This is an idea to allow users to change just the colours of the default admin theme with their own stylesheet file.

If users add a folder called AdminThemeDefault in their /site/templates/ folder and add one or more custom .css files in there called main-{theircolour}.css they will appear in the module config for selection.

The URL to the stylesheet is then added to a variable called $page->stylesheet that can be used to effectively change line 9 of default.php in the admin theme folder to this: 

$config->styles->prepend($page->stylesheet . "?v=7");

It may well benefit from some code tweaks and there may well be other, better ways of approaching this, but I think the simplest thing people will want to do to customise the admin experience is create their own colour schemes without having them wiped out during upgrades, so if something like this could be implemented before the new admin theme is  place then that opens up some possibilities and can possibly be given some fanfare when the new theme is released.

Another possibility is having a base stylesheet that's possibly monochrome (less chance of missing a colour and having an odd colour show through) and having all colour schemes simply be shortened variations of that one (or possibly something with SASS would be even easier but I don't know if this module parses those files automatically?).
