### PR TITLE
update hasAlphaChannel() for 8bit images

### DIFF
--- a/wire/core/ImageSizer.php
+++ b/wire/core/ImageSizer.php
@@ -1093,7 +1093,7 @@ class ImageSizer extends Wire {
 				@fread($f,4);
 				break; // no need for us to read further
 			}
-			elseif($type=='IEND' || $type=='iDAT' || $counter>=2048) {
+			elseif($type=='IEND' || $type=='IDAT' || $counter>=2048) {
 				break;
 			}
 			else {


### PR DESCRIPTION
update method hasAlphaChannel() to check transparency with 8bit images.
Without this, it creates black backgrounds.
Issue found by interrobang and Martijn Geerts. Thanks guys.
