### PR TITLE
Changed default sharpening value.

### DIFF
--- a/wire/core/ImageSizer.php
+++ b/wire/core/ImageSizer.php
@@ -104,7 +104,7 @@ class ImageSizer extends Wire {
 	 * default sharpening mode: [ none | soft | medium | strong ]
 	 *
 	 */
-	protected $sharpening = 'soft';
+	protected $sharpening = 'none';
 
 
 	/**


### PR DESCRIPTION
Sharpening "soft" caused quite blured images even on 1:1 crop after my update from 2.3. With the old config.php in place, one doesn't have the sharpening option visible. I think not breaking the image-croping on update is quite important, while new installations use "soft"-sharpening, because it's in the config.php.