### PR TITLE
Workaround for sharpening with buggy PHP versions

### DIFF
--- a/wire/core/ImageSizer.php
+++ b/wire/core/ImageSizer.php
@@ -1026,10 +1026,7 @@ class ImageSizer extends Wire {
 	 */
 	protected function hasAlphaChannel() {
 		$errors = array();
-		static $a = array();
-		if(isset($a['alpha'])) {
-			return $a['alpha'];
-		}
+		$a = array();
 		$f = @fopen($this->filename,'rb');
 		if($f === false) return false;
 


### PR DESCRIPTION
PHP versions 5.5.9 and 5.5.10 have a broken function imageconvolution in GD-lib
