### PR TITLE
Descriptive error message for invalid module name

### DIFF
--- a/wire/modules/Process/ProcessModule/ProcessModule.module
+++ b/wire/modules/Process/ProcessModule/ProcessModule.module
@@ -103,7 +103,7 @@ class ProcessModule extends Process {
 		foreach($this->modulesArray as $name => $installed) {
 
 			if(strpos($name, $section) !== 0 || preg_match('/' . $section . '[^A-Z]/', $name)) {
-				if(!preg_match('/^([A-Za-z][a-z]+)/', $name, $matches)) $this->error($name); 
+				if(!preg_match('/^([A-Za-z][a-z]+)/', $name, $matches)) $this->error(sprintf($this->_("Invalid module name: %s"), $name));
 				$section = $matches[1]; 
 				if($table) $out .= $table->render();
 				$table = $this->modules->get("MarkupAdminDataTable");


### PR DESCRIPTION
Error message for invalid module name was vague, to say the least. Adding better description should, at least, guide developers to correct direction without necessarily having to dig into code to find out what's wrong.
