### PR TITLE
Selecting pages with no title

### DIFF
--- a/wire/modules/Inputfield/InputfieldPageListSelect/InputfieldPageListSelectMultiple.module
+++ b/wire/modules/Inputfield/InputfieldPageListSelect/InputfieldPageListSelectMultiple.module
@@ -57,9 +57,11 @@ class InputfieldPageListSelectMultiple extends Inputfield implements InputfieldH
 		$out = "\n<ol id='{$this->id}_items'>" . $this->renderListItem("Label", "1", "itemTemplate"); 
 
 		foreach($this->value as $page_id) {
-			$page = $this->pages->get((int) $page_id); 
+			$page = $this->pages->get((int) $page_id);
+			$label = $page->get($this->labelFieldName);
+			if(!$label) $label = $page->id;
 			if(!$page || !$page->id) continue; 
-			$out .= $this->renderListItem($page->get($this->labelFieldName), $page->id); 
+			$out .= $this->renderListItem($label, $page->id); 
 		}
 		
 		$out .= "\n</ol>";


### PR DESCRIPTION
It is possible to use this _fieldtype_ for pages with no title (for example for selecting _users_). In such case, unless the fieldtype is configured to use something else than title, it displays empty items.
I've added a check for empty label, it falls back to _$page->id_. That, if I'm no mistaken, makes it somewhat coherent with _List of fields to display in the admin Page List_ field in templates' settings. Perhaps it would make more sense to add a _title_ to user pages (instead of _name_, maybe?) or replace the label with something akin to _undefined string_.
