### PR TITLE
Add new status of 'locked'.

### DIFF
--- a/wire/core/Inputfield.php
+++ b/wire/core/Inputfield.php
@@ -58,7 +58,8 @@ abstract class Inputfield extends WireData implements Module {
 	const collapsedBlank = 2; 	// will display collapsed only if blank
 	const collapsedHidden = 4; 	// will not be rendered in the form
 	const collapsedPopulated = 5; 	// will display collapsed only if populated
-	const collapsedLocked = 8;  // value is visible but not editable, otherwise same as collapsedYes
+	const collapsedLocked = 8;      // value is visible but not editable, otherwise same as collapsedYes
+	const locked = 16;              // value is not editable
 
 	/**
 	 * Constants for skipLabel setting
@@ -582,7 +583,8 @@ abstract class Inputfield extends WireData implements Module {
 		$field->addOption(self::collapsedPopulated, $this->_("Collapsed only when populated")); 
 		$field->addOption(self::collapsedYes, $this->_("Always collapsed, requiring a click to open")); 
 		$field->addOption(self::collapsedHidden, $this->_("Hidden, not shown in the editor"));
-		$field->addOption(self::collapsedLocked, $this->_("Locked, value visible but not editable"));
+		$field->addOption(self::collapsedLocked, $this->_("Locked, value visible with a click but not editable"));
+		$field->addOption(self::locked, $this->_("Locked, value visible but not editable"));
 		$field->attr('value', (int) $this->collapsed); 
 		$fieldset->append($field); 
 

--- a/wire/core/InputfieldWrapper.php
+++ b/wire/core/InputfieldWrapper.php
@@ -272,7 +272,7 @@ class InputfieldWrapper extends Inputfield {
 			$showIf = $inputfield->getSetting('showIf'); 
 			
 			if($collapsed == Inputfield::collapsedHidden) continue; 
-			if($collapsed == Inputfield::collapsedLocked) $renderValueMode = true; 
+			if($collapsed == Inputfield::locked || $collapsed == Inputfield::collapsedLocked) $renderValueMode = true;
 
 			if($renderValueMode) {
 				$ffOut = $inputfield->renderValue();
@@ -323,7 +323,7 @@ class InputfieldWrapper extends Inputfield {
 				$ffAttrs['class'] .= ' ' . $classes['item_required_if']; 
 			}
 
-			if($collapsed) {
+			if($collapsed && $collapsed != Inputfield::locked) {
 				$isEmpty = $inputfield->isEmpty();
 				if(($isEmpty && $inputfield instanceof InputfieldWrapper) || 
 					$collapsed === Inputfield::collapsedYes ||
@@ -451,6 +451,7 @@ class InputfieldWrapper extends Inputfield {
 		// skip over collapsedHidden or collapsedLocked inputfields, beacuse they are not saveable
 		if($inputfield->collapsed === Inputfield::collapsedHidden) return false;
 		if($inputfield->collapsed === Inputfield::collapsedLocked) return false;
+		if($inputfield->collapsed === Inputfield::locked) return false;
 
 		// if dependencies aren't in use, we can skip the rest
 		//if(!$this->useDependencies) return true; 


### PR DESCRIPTION
Allows a field to be uneditable but shown straight away. No need to uncollapse the field to see the value.

I'm making a PR of this as the functionality is being requested on the forums. However, the way I've implemented it here is a bit of kludge as it breaks the semantics of the "collapsed" variable. Perhaps a simple change of the new value from 'locked' to 'collapsedNoButLocked' would be sufficient to restore your semantics. In addition, I pulled the fixed value of 16 out of thin air as I have no idea how you picked the original const values.
