### PR TITLE
Add default rendering for array-valued inputs.

### DIFF
--- a/wire/core/Inputfield.php
+++ b/wire/core/Inputfield.php
@@ -465,7 +465,12 @@ abstract class Inputfield extends WireData implements Module {
 	 *
 	 */
 	public function ___renderValue() {
-		$out = htmlentities($this->attr('value'), ENT_QUOTES, "UTF-8"); 
+
+		$value = $this->attr('value');
+		if (is_array($value)) {
+			$value = implode($this->_(', '), $value);
+		}
+		$out = htmlentities($value, ENT_QUOTES, "UTF-8");
 		return $out; 
 	}
 


### PR DESCRIPTION
Simplistic default support for multi-value inputs that don't override `renderValue()`.

This really only comes in to play if a multi-value input is included in a template with visibility set to "collapsedLocked."
