### PR TITLE
Add Content-Type header to plaintext email

### DIFF
--- a/wire/core/WireMail.php
+++ b/wire/core/WireMail.php
@@ -359,6 +359,7 @@ class WireMail extends WireData implements WireMailInterface {
 				"$html\r\n\r\n" . 
 				"--$boundary--\r\n";
 		} else {
+			$header .= "\r\nContent-Type: text/plain; charset=\"utf-8\""; 
 			$body = $text; 
 		}
 


### PR DESCRIPTION
To avoid charset conflict with special characters on plaintext email content.
