### PR TITLE
make defaultGamma optionally configurable

### DIFF
--- a/wire/core/ImageSizer.php
+++ b/wire/core/ImageSizer.php
@@ -257,10 +257,6 @@ class ImageSizer extends Wire {
 
 		if(!$image) return false;
 
-		// optionally make defaultGamma configurable via $config->defaultGamma, instead of hardcoding its value
-		$this->defaultGamma = isset(wire('config')->defaultGamma) ? wire('config')->defaultGamma : $this->defaultGamma;
-		if(1 > $this->defaultGamma || 4 < $this->defaultGamma) $this->defaultGamma = 2.0;
-		$this->defaultGamma = floatval($this->defaultGamma);
 		if($this->imageType != IMAGETYPE_PNG || ! $this->hasAlphaChannel()) {
 			// @horst: linearize gamma to 1.0 - we do not use gamma correction with pngs containing alphachannel, because GD-lib  doesn't respect transparency here (is buggy)
 			imagegammacorrect($image, $this->defaultGamma, 1.0);


### PR DESCRIPTION
via $config->defaultGamma, instead of only using a hardcoded value here in the class.

https://processwire.com/talk/topic/6096-imagick-resizer-need-to-be-tested-2/page-2#entry61578
