### PR TITLE
fix bug ProcessPageList.js

### DIFF
--- a/wire/modules/Process/ProcessPageList/ProcessPageList.js
+++ b/wire/modules/Process/ProcessPageList/ProcessPageList.js
@@ -725,7 +725,7 @@ $(document).ready(function() {
 					title = '';
 				}
 
-				if(id != $container.val()) $container.change().val(id);
+				if(id != $container.val()) $container.val(id).change();
 
 				if(options.selectShowPageHeader) { 
 					$header.children(".PageListSelectName").text(title); 


### PR DESCRIPTION
fix bug with setting the value for the hidden form input.
change event would get triggered before value changed, so other scripts like inputfield.js dependencies did not work, or possibly other script listening to on change would fail getting the value.

it should be in order val(someval).change()
