### PR TITLE
write PNG files with compression 9

### DIFF
--- a/wire/core/ImageSizer.php
+++ b/wire/core/ImageSizer.php
@@ -396,9 +396,7 @@ class ImageSizer extends Wire {
 				break;
 			case IMAGETYPE_PNG: 
 				if(! $this->hasAlphaChannel()) imagegammacorrect($thumb2, 1.0, $this->defaultGamma);
-				// convert 1-100 (worst-best) scale to 0-9 (best-worst) scale for PNG 
-				$quality = round(abs(($this->quality - 100) / 11.111111)); 
-				$result = imagepng($thumb2, $dest, $quality); 
+				$result = imagepng($thumb2, $dest, 9); 
 				break;
 			case IMAGETYPE_JPEG:
 				// correct gamma from linearized 1.0 back to 2.0


### PR DESCRIPTION
the quality setting only makes sense for jpegs. Pngs are lossless. Here we only need a setting for compresion level 0-9. But I always would use the max compression.

see the linked post: https://processwire.com/talk/topic/6322-png-image-filesize-after-upload-issue/#entry62030 and the first post of this thread. Also the testcase without that change shows how drastically the filesizes actually are: http://images.pw.nogajski.de/image-sizer-core/formats/quality-vs-compression/
