### PR TITLE
Config extension

### DIFF
--- a/index.php
+++ b/index.php
@@ -108,6 +108,14 @@ function ProcessWireBootConfig() {
 	$config->paths->sessions = $config->paths->assets . "sessions/";
 
 	/*
+	 * Setup required software versions
+	 *
+	 */
+	$config->versions = new WireData();
+	$config->versions->php   = '5.3.8';
+	$config->versions->mysql = '5.0.15';
+
+	/*
 	 * Styles and scripts are CSS and JS files, as used by the admin application.
 	 * But reserved here if needed by other apps and templates.
 	 *


### PR DESCRIPTION
@ryancramerdesign

I'm working on a diagnostics module for PW and rather than have the module encode a matrix of PW versions to Min PHP and Min MySQL versions it would be nice to have PW simply declare what it needs.
(Obviously it can only do this going forward so there will need to be a mapping for prior versions.)

Would adding ProcessWire's required versions for PHP and MySQL to the $config impact anything? 

Doing this would allow PW to declare its own requirements, rather than having other things try to encode that knowledge.
