### PR TITLE
Fixed a language-related error when doing a "PageFinder::getQuery" 

### DIFF
--- a/wire/modules/LanguageSupport/LanguageSupportPageNames.module
+++ b/wire/modules/LanguageSupport/LanguageSupportPageNames.module
@@ -541,7 +541,7 @@ class LanguageSupportPageNames extends WireData implements Module, ConfigurableM
 		if(!wire('pages')->outputFormatting) return;
 
 		$language = wire('user')->language; 
-		if($language->isDefault()) return;
+		if(!$language || $language->isDefault()) return;
 
 		$status = "status" . (int) $language->id;	
 		$query->where("pages.$status>0"); 


### PR DESCRIPTION
Hi Ryan,

This is a proposed fix for a PHP error that occurs when the current user has no language field, for example in the following case:

1.  call wire("session")->login(...)
2.  search for a given page in the sites pages,
3. redirect the session to this page.

If the logged-in user has no defined language field, there is a php error during step 2 (like: calling "isDefault() on a non object).