### PR TITLE
fix missing parent slash for disabled slashUrls

### DIFF
--- a/wire/modules/Inputfield/InputfieldPageName/InputfieldPageName.module
+++ b/wire/modules/Inputfield/InputfieldPageName/InputfieldPageName.module
@@ -142,7 +142,7 @@ class InputfieldPageName extends InputfieldName implements ConfigurableModule {
 		$link = '';
 
 		if($value && wire('modules')->isInstalled('LanguageSupportPageNames')) {
-			if (strlen($value)) {
+            if (strlen($value)) {
                 $lastSegment = ((int) $this->slashUrls) ? "/$value/" : $value;
                 $link = "<a href='" . rtrim(wire('config')->urls->root, '/') . rtrim($url, '/') . "/$lastSegment'>";
             }

--- a/wire/modules/Inputfield/InputfieldPageName/InputfieldPageName.module
+++ b/wire/modules/Inputfield/InputfieldPageName/InputfieldPageName.module
@@ -142,10 +142,10 @@ class InputfieldPageName extends InputfieldName implements ConfigurableModule {
 		$link = '';
 
 		if($value && wire('modules')->isInstalled('LanguageSupportPageNames')) {
-            if (strlen($value)) {
-                $lastSegment = ((int) $this->slashUrls) ? "/$value/" : $value;
-                $link = "<a href='" . rtrim(wire('config')->urls->root, '/') . rtrim($url, '/') . "/$lastSegment'>";
-            }
+			if (strlen($value)) {
+				$lastSegment = ((int) $this->slashUrls) ? "/$value/" : $value;
+				$link = "<a href='" . rtrim(wire('config')->urls->root, '/') . rtrim($url, '/') . "/$lastSegment'>";
+			}
 		}
 		
 		$slashUrls = (int) $this->slashUrls;

--- a/wire/modules/Inputfield/InputfieldPageName/InputfieldPageName.module
+++ b/wire/modules/Inputfield/InputfieldPageName/InputfieldPageName.module
@@ -142,13 +142,16 @@ class InputfieldPageName extends InputfieldName implements ConfigurableModule {
 		$link = '';
 
 		if($value && wire('modules')->isInstalled('LanguageSupportPageNames')) {
-			if(strlen($value)) $link = "<a href='" . rtrim(wire('config')->urls->root, '/') . rtrim($url, '/') . "/$value/'>";
+			if (strlen($value)) {
+                $lastSegment = ((int) $this->slashUrls) ? "/$value/" : $value;
+                $link = "<a href='" . rtrim(wire('config')->urls->root, '/') . rtrim($url, '/') . "/$lastSegment'>";
+            }
 		}
 		
 		$slashUrls = (int) $this->slashUrls;
 		$p = "\n<p id='{$this->id}_path' data-slashUrls='$slashUrls' class='InputfieldPageNameURL'>";
 		if($link) $p .= $link;
-		$p .= "$url<strong></strong>";
+		$p .= rtrim($url, '/') . "/<strong></strong>";
 		if($link) $p .= "</a>";
 		$p .= "</p>";
 


### PR DESCRIPTION
Add the missing trailing slash for the parents url before the current page name (which is inside the strong tag and gets updated onChange evento of the page name field)
- before: /shop/catalog/productproduct-a
- fix   : /shop/catalog/product/product-a
