### PR TITLE
Added (de-) select-all-feature for checkboxes

### DIFF
--- a/wire/modules/Inputfield/InputfieldCheckboxes/InputfieldCheckboxes.css
+++ b/wire/modules/Inputfield/InputfieldCheckboxes/InputfieldCheckboxes.css
@@ -26,3 +26,8 @@
 	padding-bottom: 1%; 
 }
 
+.InputfieldCheckboxesSelectAll {
+	margin-top: 4px;
+	font-size: .8em;
+}
+

--- a/wire/modules/Inputfield/InputfieldCheckboxes/InputfieldCheckboxes.js
+++ b/wire/modules/Inputfield/InputfieldCheckboxes/InputfieldCheckboxes.js
@@ -1,26 +1,57 @@
 jQuery(function ($) {
 
-  var $selectAll = $('.InputfieldCheckboxesSelectAll a'),
-      $removeField = $('[name^="remove_fields"]'),
-      allChecked = false;
+  /**
+   * Iterating over all occurrences of the input field
+   * on the page.
+   */
+  $('.InputfieldCheckboxesSelectAll').each(function () {
 
-  $selectAll.on('click', function () {
-    allChecked = !allChecked;
-    $removeField.attr('checked', allChecked);
-    $(this).text(allChecked ? InputfieldCheckboxesConfig.deSelectAll : InputfieldCheckboxesConfig.selectAll);
-  });
+    var $selectAll = $(this).find('a'),
+        $checkboxes = $('#' + this.id.replace('-select-all', '')).find('input[type="checkbox"]'),
+        allChecked = false;
 
-  $removeField.on('change', function () {
-    var allCheckedLen = $.grep($removeField, function (item) {
-      return item.checked;
-    }).length;
-    if ( allCheckedLen === $removeField.length ) {
-      allChecked = true;
-      $selectAll.text(InputfieldCheckboxesConfig.deSelectAll);
-      return;
+    /**
+     * Changes all enabled checkboxes.
+     * 
+     * @return {boolean} True, if at least one checkbox changed
+     */
+    function unCheckAll() {
+      var changed = 0;
+      $.each($checkboxes, function () {
+        if ( !this.disabled ) {
+          this.checked = !allChecked;
+          changed += 1;
+        }
+      });
+      return !!changed;
     }
-    allChecked = false;
-    $selectAll.text(InputfieldCheckboxesConfig.selectAll);
-  })
+
+    /**
+     * Handling '(De-) Select all'-clicks
+     */
+    $selectAll.on('click', function () {
+      if ( unCheckAll() ) {
+        allChecked = !allChecked;
+        $selectAll.text(allChecked ? InputfieldCheckboxesConfig.deSelectAll : InputfieldCheckboxesConfig.selectAll);
+      }
+    });
+
+    /**
+     * Handling checkbox state changes.
+     */
+    $checkboxes.on('change', function () {
+      var allCheckedLen = $.grep($checkboxes, function (item) {
+        return item.checked;
+      }).length;
+      if ( allCheckedLen === $checkboxes.length ) {
+        allChecked = true;
+        $selectAll.text(InputfieldCheckboxesConfig.deSelectAll);
+        return;
+      }
+      allChecked = false;
+      $selectAll.text(InputfieldCheckboxesConfig.selectAll);
+    });
+
+  });
 
 });

--- a/wire/modules/Inputfield/InputfieldCheckboxes/InputfieldCheckboxes.js
+++ b/wire/modules/Inputfield/InputfieldCheckboxes/InputfieldCheckboxes.js
@@ -1,0 +1,26 @@
+jQuery(function ($) {
+
+  var $selectAll = $('.InputfieldCheckboxesSelectAll a'),
+      $removeField = $('[name^="remove_fields"]'),
+      allChecked = false;
+
+  $selectAll.on('click', function () {
+    allChecked = !allChecked;
+    $removeField.attr('checked', allChecked);
+    $(this).text(allChecked ? InputfieldCheckboxesConfig.deSelectAll : InputfieldCheckboxesConfig.selectAll);
+  });
+
+  $removeField.on('change', function () {
+    var allCheckedLen = $.grep($removeField, function (item) {
+      return item.checked;
+    }).length;
+    if ( allCheckedLen === $removeField.length ) {
+      allChecked = true;
+      $selectAll.text(InputfieldCheckboxesConfig.deSelectAll);
+      return;
+    }
+    allChecked = false;
+    $selectAll.text(InputfieldCheckboxesConfig.selectAll);
+  })
+
+});

--- a/wire/modules/Inputfield/InputfieldCheckboxes/InputfieldCheckboxes.module
+++ b/wire/modules/Inputfield/InputfieldCheckboxes/InputfieldCheckboxes.module
@@ -15,6 +15,7 @@ class InputfieldCheckboxes extends InputfieldSelectMultiple implements Inputfiel
 		$this->set('table', false); 
 		$this->set('thead', ''); 
 		$this->set('optionColumns', 0); 
+		wire('modules')->get('JqueryCore');
 		parent::init();
 		$this->set('size', null); // cancel 'size' attribute used by select multiple
 	}
@@ -32,7 +33,7 @@ class InputfieldCheckboxes extends InputfieldSelectMultiple implements Inputfiel
 		if($this->table) {
 			$table = $this->modules->get("MarkupAdminDataTable"); 
 			$table->setEncodeEntities(false);
-			if($this->thead) $table->headerRow(explode('|', htmlspecialchars($this->thead))); 
+			if($this->thead) $table->headerRow(explode('|', htmlspecialchars($this->thead)));
 
 		} else if($columns) {
 
@@ -63,7 +64,7 @@ class InputfieldCheckboxes extends InputfieldSelectMultiple implements Inputfiel
 			$attrs = $this->getOptionAttributesString($attrs);
 			if($attrs) $attrs = ' ' . $attrs; 
 
-			$value = $this->entityEncode($value); 
+			$value = $this->entityEncode($value);
 
 			$input = "<label$attrs>" . 
 				"<input$checked " . 
@@ -79,11 +80,21 @@ class InputfieldCheckboxes extends InputfieldSelectMultiple implements Inputfiel
 			} else {
 				$out .= "\n\t<li$liAttr>" . $input . $value . "</label></li>";
 			}
-			
+
 		}
 
-		if($table) $out .= $table->render();
-			else $out .= "\n</ul>";
+		if($table) {
+			$out .= $table->render();
+		} else {
+			$out .= "\n</ul>";
+			if(!$columns) {
+				$out .= "<div class='InputfieldCheckboxesSelectAll'>" .
+					" <a href='javascript:;'>Select all</a></div>" .
+					"<script>var InputfieldCheckboxesConfig = {" .
+					"\tselectAll: '" . $this->_('Select all') . "'," .
+					"\tdeSelectAll: '" . $this->_('Deselect all') . "'" .
+					"};</script>";
+			}
 
 		return $out; 
 
@@ -105,7 +116,7 @@ class InputfieldCheckboxes extends InputfieldSelectMultiple implements Inputfiel
 		$f->description = $this->_('If you want the checkboxes to display in columns (rather than stacked), enter the number of columns you want to use (up to 10). To display checkboxes side-by-side (inline) enter 1.'); 
 		$f->attr('name', 'optionColumns'); 
 		$f->attr('value', (int) $this->optionColumns); 
-		$inputfields->add($f);	
+		$inputfields->add($f); 
 		return $inputfields; 
 	}
 

--- a/wire/modules/Inputfield/InputfieldCheckboxes/InputfieldCheckboxes.module
+++ b/wire/modules/Inputfield/InputfieldCheckboxes/InputfieldCheckboxes.module
@@ -33,7 +33,7 @@ class InputfieldCheckboxes extends InputfieldSelectMultiple implements Inputfiel
 		if($this->table) {
 			$table = $this->modules->get("MarkupAdminDataTable"); 
 			$table->setEncodeEntities(false);
-			if($this->thead) $table->headerRow(explode('|', htmlspecialchars($this->thead)));
+			if($this->thead) $table->headerRow(explode('|', htmlspecialchars($this->thead))); 
 
 		} else if($columns) {
 
@@ -51,7 +51,7 @@ class InputfieldCheckboxes extends InputfieldSelectMultiple implements Inputfiel
 			$ulClass = 'InputfieldCheckboxesStacked';
 		}
 
-		if(!$table) $out = "\n<ul class='$ulClass'>";
+		if(!$table) $out = "\n<ul class='$ulClass' id='checkboxes-{$this->name}'>";
 
 		foreach($this->getOptions() as $key => $value) {
 			$checked = '';
@@ -64,7 +64,7 @@ class InputfieldCheckboxes extends InputfieldSelectMultiple implements Inputfiel
 			$attrs = $this->getOptionAttributesString($attrs);
 			if($attrs) $attrs = ' ' . $attrs; 
 
-			$value = $this->entityEncode($value);
+			$value = $this->entityEncode($value); 
 
 			$input = "<label$attrs>" . 
 				"<input$checked " . 
@@ -88,9 +88,9 @@ class InputfieldCheckboxes extends InputfieldSelectMultiple implements Inputfiel
 		} else {
 			$out .= "\n</ul>";
 			if(!$columns) {
-				$out .= "<div class='InputfieldCheckboxesSelectAll'>" .
+				$out .= "<div class='InputfieldCheckboxesSelectAll' id='checkboxes-{$this->name}-select-all'>" .
 					" <a href='javascript:;'>Select all</a></div>" .
-					"<script>var InputfieldCheckboxesConfig = {" .
+					"<script>var InputfieldCheckboxesConfig = InputfieldCheckboxesConfig || {" .
 					"\tselectAll: '" . $this->_('Select all') . "'," .
 					"\tdeSelectAll: '" . $this->_('Deselect all') . "'" .
 					"};</script>";
@@ -116,7 +116,7 @@ class InputfieldCheckboxes extends InputfieldSelectMultiple implements Inputfiel
 		$f->description = $this->_('If you want the checkboxes to display in columns (rather than stacked), enter the number of columns you want to use (up to 10). To display checkboxes side-by-side (inline) enter 1.'); 
 		$f->attr('name', 'optionColumns'); 
 		$f->attr('value', (int) $this->optionColumns); 
-		$inputfields->add($f); 
+		$inputfields->add($f);  
 		return $inputfields; 
 	}
 


### PR DESCRIPTION
Hi.

I added a feature that I've been missing for a long time now — the possibility to (de-) select all checkboxes e. g. when confirming the deletion of fields from a template.

Btw: this is my first contribution to ProcessWire and chances are that I missed some important detail, best practice, or the like. If this is the case I'm sorry. I don't want to waste anybody's time here!

Sincerly
Emanuel
