### PR TITLE
added "crop _before_ resize" functionality

### DIFF
--- a/wire/core/ImageSizer.php
+++ b/wire/core/ImageSizer.php
@@ -89,6 +89,16 @@ class ImageSizer extends Wire {
 	protected $cropping = true;
 
 	/**
+	 * This can be populated on a per image basis. It provides cropping first and then resizing, the opposite of the default behave
+	 *
+	 * It needs an array with 4 params: x y w h for the cropping rectangle
+	 * 
+	 * Default is: null
+	 *
+	 */
+	protected $cropExtra = null;
+
+	/**
 	 * Was the given image modified?
 	 *
 	 */
@@ -277,6 +287,23 @@ class ImageSizer extends Wire {
 			if($orientations[1] > 0) {
 				$image = $this->imFlip($image, ($orientations[1] == 2 ? true : false));
 			}
+		}
+
+		// if there is requested to crop _before_ resize, we do it here
+		if(is_array($this->cropExtra)) {
+			$imageTemp = imagecreatetruecolor(imagesx($image), imagesy($image));  // create an intermediate memory image
+			imagecopy($imageTemp, $image, 0, 0, 0, 0, imagesx($image), imagesy($image)); // copy our initial image into the intermediate one
+			imagedestroy($image); // release the initial image
+			// get crop values and create a new initial image
+			list($x, $y, $w, $h) = $this->cropExtra;
+			$image = imagecreatetruecolor($w, $h);
+			$this->prepareImageLayer($image, $imageTemp);
+			imagecopy($image, $imageTemp, 0, 0, $x, $y, $w, $h);
+			unset($x, $y, $w, $h);
+			// now release the intermediate image and update settings
+			imagedestroy($imageTemp);
+			$this->setImageInfo(imagesx($image), imagesy($image));
+			#$this->cropping = false; // ?? set this to prevent overhead with the following manipulation ??
 		}
 
 		// here we check for cropping, upscaling, sharpening
@@ -744,6 +771,37 @@ class ImageSizer extends Wire {
 		return $this; 
 	}
 
+	/**
+	 * Set values for cropExtra rectangle
+	 *
+	 * @param array $value containing 4 params (x y w h) indexed or associative
+	 * @return $this
+	 * @throws WireException when given invalid value
+	 *
+	 */
+	public function setcropExtra($value) {
+		$this->cropExtra = null;
+		if(!is_array($value) || 4!=count($value)) {
+			throw new WireException('Missing or wrong paramArray for Imagesizer-cropExtra!');
+		}
+		if(array_keys($value) === range(0, count($value) - 1)) {
+			// we have a zerobased sequential array, we assume this order: x y w h
+			list($x, $y, $w, $h) = $value;
+		} else {
+			// check for associative array
+			foreach(array('x','y','w','h') as $v) {
+				if(isset($value[$v])) $$v = $value[$v];
+			}
+		}
+		foreach(array('x','y','w','h') as $k) {
+			$v = isset($$k) ? $$k : -1;
+			if(!is_int($v) || $v<0) throw new WireException("Missing or wrong param $k for Imagesizer-cropExtra!");
+			if(('w'==$k || 'h'==$k) && 0==$v) throw new WireException("Wrong param $k for Imagesizer-cropExtra!");
+		}
+		$this->cropExtra = array($x, $y, $w, $h);
+		return $this;
+	}
+
 
 	/**
 	 * Alternative to the above set* functions where you specify all in an array
@@ -768,6 +826,7 @@ class ImageSizer extends Wire {
 				case 'quality': $this->setQuality($value); break;
 				case 'cropping': $this->setCropping($value); break;
 				case 'defaultGamma': $this->setDefaultGamma($value); break;
+				case 'cropExtra': $this->setcropExtra($value); break;
 				
 				default: 
 					// unknown or 3rd party option


### PR DESCRIPTION
this is to allow third party modules like Thumbnails to delegate their complete image manipulation to ImageSizer, - or to any dropped in PageimageSizerModule!

It is not intended to call this manually.

@Ryan: I have tested this with Thumbnails module and it works well. But just for quick testing, the following code can be executed in a template:

$image = $page->images->first();
$image->removeVariations();
$x = 50;
$y = 150;
$w = intval(($image->width - $x) / 2);
$h = intval(($image->height - $y) / 2);
$options = array('cropExtra'=>array('x'=>$x, 'w'=>$w, 'y'=>$y, 'h'=>$h));
$img = $image->size(intval($w \* 0.8), intval($h \* 0.8), $options);
echo "&#60;&#105;&#109;&#103;&#32;&#115;&#114;&#99;&#61;&#39;&#123;&#36;&#105;&#109;&#103;&#45;&#62;&#117;&#114;&#108;&#125;&#39;&#32;&#47;&#62;&#32; $img->name";
