### PR TITLE
using keys to identify locks + removing locks

### DIFF
--- a/wire/core/Fuel.php
+++ b/wire/core/Fuel.php
@@ -28,11 +28,11 @@ class Fuel implements IteratorAggregate {
 	 * 
 	 */
 	public function set($key, $value, $lock = false) {
-		if(in_array($key, $this->lock) && $value !== $this->data[$key]) {
+		if(isset($this->lock[$key])) {
 			throw new WireException("API variable '$name' is locked and may not be set again"); 
 		}
 		$this->data[$key] = $value; 
-		if($lock) $this->lock[] = $key;
+		if($lock) $this->lock[$key] = true;
 		return $this;
 	}
 
@@ -46,6 +46,7 @@ class Fuel implements IteratorAggregate {
 	public function remove($key) {
 		if(isset($this->data[$key])) {
 			unset($this->data[$key]);
+			if(isset($this->lock[$key])) unset($this->lock[$key]);
 			return true;
 		}
 		return false;


### PR DESCRIPTION
just some thoughts:
1. if data[$key] is already locked prevent overwriting it even if new_value === old_value
2. remove own lock (if set) on $key removal

in the original version we could repeatedly call set('mykey', 'myvalue', true) and we would end up with a $lock array containing more than 1 element for the same locked key : array('mykey', 'mykey',...).

please verify, kind regards
