### PR TITLE
Optional HTML5 placeholder for admin search field

### DIFF
--- a/wire/modules/Process/ProcessPageSearch/ProcessPageSearch.module
+++ b/wire/modules/Process/ProcessPageSearch/ProcessPageSearch.module
@@ -865,7 +865,7 @@ class ProcessPageSearch extends Process implements ConfigurableModule {
 		return $a; 
 	}
 
-	public function renderSearchForm($placeholder = null) {
+	public function renderSearchForm($placeholder = '') {
 
 		$q = substr($this->input->get->q, 0, 128);
 		$q = htmlentities($q, ENT_QUOTES, "UTF-8");


### PR DESCRIPTION
Update to pass an optional HTML5 placeholder attribute to renderSearchForm();

Example: 
$modules->get('ProcessPageSearch')->renderSearchForm('Search');
