### PR TITLE
multiline selector

### DIFF
--- a/wire/core/Pages.php
+++ b/wire/core/Pages.php
@@ -116,6 +116,8 @@ class Pages extends Wire {
 		$loadPages = true; 
 		$debug = $this->wire('config')->debug; 
 		if(array_key_exists('loadPages', $options)) $loadPages = (bool) $options['loadPages'];
+		
+		$selectorString = preg_replace('/(\r\n|\n)/', '', $selectorString);
 
 		if(!strlen($selectorString)) return new PageArray();
 		if($selectorString === '/' || $selectorString === 'path=/') $selectorString = 1;


### PR DESCRIPTION
allowing long selector to be splitted among multiple lines for better readability as in:

``` php
$results = $pages->find("
    template!=blog-post|blog-category,
    parent={$somePage->id},
    title|headline|summary|body*={$q},
    sort=title,
    start=0, limit=10
");
```

please verify for any side effects
