### PR TITLE
fix non default language home path

### DIFF
--- a/wire/modules/LanguageSupport/LanguageSupportPageNames.module
+++ b/wire/modules/LanguageSupport/LanguageSupportPageNames.module
@@ -326,20 +326,22 @@ class LanguageSupportPageNames extends WireData implements Module, ConfigurableM
 	public function getPagePath(Page $page, Language $language) {
 
 		$isDefault = $language->isDefault();
-
-		if($page->id == 1) {
+		
+		$rootPageID = wire('config')->rootPageID;
+		
+		if($page->id == $rootPageID) {
 			// special case: homepage
 			$name = $isDefault ? '' : $page->get("name$language"); 
 			if($isDefault && $this->useHomeSegment) $name = $page->name;
 			if($name == self::HOME_NAME_DEFAULT || !strlen($name)) return '/';
-			return "/$name/";
+			return $page->template->slashUrls ? "/$name/" : "/$name";
 		}
 
 		$path = '';
 
 		foreach($page->parents() as $parent) {
 			$name = $isDefault ? $parent->get("name") : $parent->get("name$language|name"); 
-			if($parent->id == 1) { 
+			if($parent->id == $rootPageID) { 
 				// bypass ProcessWire's default homepage name of 'home', as we don't want it in URLs
 				if($name == self::HOME_NAME_DEFAULT) continue; 
 				// avoid having default language name inherited at homepage level


### PR DESCRIPTION
line 337
if slashUrls is disabled for the hompage url are generated with a trailing slash (i.e. /es/) and the consequence is a redirect ( to /es)

please also verify:
should we always use wire('config')->rootPageID when checking for the root page instead of the integer 1?

kind regards
