### PR TITLE
Reset the pdo to null, so can create a fresh connection when long runnin...

### DIFF
--- a/wire/core/DatabaseQuery.php
+++ b/wire/core/DatabaseQuery.php
@@ -81,9 +81,17 @@ abstract class DatabaseQuery extends WireData {
 	 *
 	 */
 	public function execute() {
-		$database = $this->wire('database');
-		$query = $database->prepare($this->getQuery()); 
-		$query->execute();
+		try {
+			$database = $this->wire('database');
+			$query = $database->prepare($this->getQuery());
+			$query->execute();
+		} catch (Exception $e) {
+			$msg = $e->getMessage();
+			if (strstr($msg, 'MySQL server has gone away')) {
+				$database->closePdo();
+			}
+			throw new Exception($e->getMessage());
+		}
 		return $query;
 	}
 

--- a/wire/core/WireDatabasePDO.php
+++ b/wire/core/WireDatabasePDO.php
@@ -299,4 +299,8 @@ class WireDatabasePDO extends Wire implements WireDatabase {
 		return parent::__get($key);
 	}
 
+	public function closePdo()
+	{
+		$this->pdo = null;
+	}
 }


### PR DESCRIPTION
...g jobs are working. There is a chance of at-least one query will get missed for the error happened. What we can do is catch the error and execute it once again setting a flag so it will not execute more than once.
