### PR TITLE
fix missing end quotes on 404 messages in htaccess

### DIFF
--- a/htaccess.txt
+++ b/htaccess.txt
@@ -26,11 +26,11 @@ ErrorDocument 404 /index.php
 # -----------------------------------------------------------------------------------------------
 
 <Files favicon.ico>
-  ErrorDocument 404 "The requested file favicon.ico was not found.
+  ErrorDocument 404 "The requested file favicon.ico was not found."
 </Files>
 
 <Files robots.txt>
-  ErrorDocument 404 "The requested file robots.txt was not found.
+  ErrorDocument 404 "The requested file robots.txt was not found."
 </Files>
 
 # -----------------------------------------------------------------------------------------------


### PR DESCRIPTION
Perhaps it's okay to leave quotes uncloses in htaccess files, but seems safer to close them?
