### PR TITLE
Add support for same-line “block comments”

### DIFF
--- a/wire/modules/LanguageSupport/LanguageParser.php
+++ b/wire/modules/LanguageSupport/LanguageParser.php
@@ -226,7 +226,11 @@ class LanguageParser extends Wire {
 		$this->numFound++;
 
 		// check if there are comments in the $tail and record them if so
-		if(($pos = strpos($tail, '//')) !== false) $comments = substr($tail, $pos+2); 
+		if(($pos = strpos($tail, '//')) !== false) {
+			$comments = substr($tail, $pos+2);			
+		} else if (($posStart = strpos($tail, '/*')) > 0 && ($posEnd = strpos($tail, '*/')) > $posStart) {
+			$comments = substr($tail, $posStart+2, $posEnd-$posStart-2);
+		}
 
 		// check if a plural was found and set an automatic comment to indicate which is which
 		if($plural) {


### PR DESCRIPTION
I’m sorry if this is silly, but it felt intuitive that one would be able to do this, and the additional code seems negligible.

The use case is that one may want to include some HTML (or even the closing `?>`) on the same line as a translatable string that isn’t supposed to show up on the translation page. Such as:

``` php
<p><?php echo __('ab'); /* As in “Starting at 90 €” */ ?> <em><?php echo $page->price; ?>&thinsp;&euro;</em></p>
```

It sometimes feels cleaner than storing the translated string in a one-off variable on a separate line.
