### PR TITLE
clarify how _init.php is included in beginner profile

### DIFF
--- a/site-beginner/templates/_init.php
+++ b/site-beginner/templates/_init.php
@@ -3,6 +3,12 @@
 /**
  * Shared functions or variables for all template files 
  *
+ * This file is automatically prepended to all template files as a result of:
+ * $config->prependTemplateFile = '_init.php'; in /site/config.php. 
+ *
+ * If you want to disable this automatic inclusion for any given template, 
+ * go in your admin to Setup > Templates > [some-template] and click on the 
+ * "Files" tab. Check the box to "Disable automatic prepend file". 
  */
 
 /** 


### PR DESCRIPTION
This really confused me for a while... based on the docs about the beginner profile I assumed there was some magic functionality of PW that always included an `_init.php` file (which seemed very un-PW-like to have such magic for the templates, so I'm glad that is not the case!), so I thought it might help other beginners to clarify the comments around this. Note that the addition to the comments is copy-pasted exactly from `/site-default/templates/_init.php`.

I could understand that maybe you want to keep this file sparse and simple for beginners -- in that case, I'd suggest at least clarifying how this works on the docs page: http://processwire.com/docs/tutorials/default-site-profile/page2

Thanks!