### PR TITLE
Make theme HTTPS (SSL) friendly

### DIFF
--- a/site-default/templates/_main.php
+++ b/site-default/templates/_main.php
@@ -35,7 +35,7 @@
 	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 	<title><?php echo $title; ?></title>
 	<meta name="description" content="<?php echo $page->summary; ?>" />
-	<link href='http://fonts.googleapis.com/css?family=Lusitana:400,700|Quattrocento:400,700' rel='stylesheet' type='text/css' />
+	<link href='//fonts.googleapis.com/css?family=Lusitana:400,700|Quattrocento:400,700' rel='stylesheet' type='text/css' />
 	<link rel="stylesheet" type="text/css" href="<?php echo $config->urls->templates?>styles/main.css" />
 </head>
 <body class="<?php if($sidebar) echo "has-sidebar "; ?>">


### PR DESCRIPTION
Fonts from googleapis.com was http, should be // so true HTTPS sites does not have insecure script (that many times does not load in modern browsers by default, in this case the fonts from google).
