### PR TITLE
fix php notices for certain process children

### DIFF
--- a/wire/modules/Process/ProcessList.module
+++ b/wire/modules/Process/ProcessList.module
@@ -57,7 +57,7 @@ class ProcessList extends Process {
 				$class = '';
 				
 			} else {
-				
+				$class = '';
 				$title = $child->get("title|name"); 
 				if($child->template == 'admin') {
 					$summary = $this->_('The process module assigned to this page does not appear to be installed.'); 


### PR DESCRIPTION
When a child is neither a page with the `admin` template nor has a `process` assigned the `$class` variable was not defined although accessed later in all cases, this fixes that.
