### PR TITLE
Allow setting root url when running outside a web server

### DIFF
--- a/index.php
+++ b/index.php
@@ -54,8 +54,8 @@ function ProcessWireBootConfig() {
 
 	} else {
 		// when included from another app or command line script
-		$httpHost = '';
-		$rootURL = '/';
+		$httpHost = getenv("PROCESSWIRE_HOST") ? getenv("PROCESSWIRE_HOST") : '';
+		$rootURL  = getenv("PROCESSWIRE_ROOT") ? getenv("PROCESSWIRE_ROOT") : '/';
 	}
 
 	/*


### PR DESCRIPTION
When running PW code from eg. cron, I'd like to be able to still use `$config->urls->...`. This (untested) patch allows feeding the relevant via environment variables.
