### PR TITLE
Keep the same language when logging out

### DIFF
--- a/wire/core/Session.php
+++ b/wire/core/Session.php
@@ -424,6 +424,7 @@ class Session extends Wire implements IteratorAggregate {
 		$user = $this->wire('user'); 
 		$guest = $this->wire('users')->getGuestUser();
 		$this->wire('users')->setCurrentUser($guest); 
+		if ($this->wire('languages') && $user->language) $this->wire('user')->language = $user->language;
 		$this->trackChange('logout', $user, $guest); 
 		if($user) $this->logoutSuccess($user); 
 		return $this; 


### PR DESCRIPTION
Fixes the issue mentioned [here](https://processwire.com/talk/topic/8843-translated-string-wont-display/?p=85372).

The problem is that after logging out, and if one stays on the same page, the language is reset to default. If the page is reloaded, the language is then set correctly again, since it is pulled from the path.

The fix manually sets the language after the user has been set back to guest.