### PR TITLE
Add support for clearing cache for pages matching custom selector

### DIFF
--- a/wire/core/Template.php
+++ b/wire/core/Template.php
@@ -56,7 +56,7 @@
  * @property int $useCacheForUsers Use cache for: 0 = only guest users, 1 = guests and logged in users
  * @property int $cacheExpire Expire the cache for all pages when page using this template is saved? (1 = yes, 0 = no- only current page)
  * @property array $cacheExpirePages Array of Page IDs that should be expired, when cacheExpire == Template::cacheExpireSpecific
- * @property array $cacheExpireSelector Selector string matching pages that should be expired, when cacheExpire == Template::cacheExpireSpecific
+ * @property array $cacheExpireSelector Selector string matching pages that should be expired, when cacheExpire == Template::cacheExpireSelector
  * @property string $tags Optional tags that can group this template with others in the admin templates list 
  * @property string $tabContent Optional replacement for default "Content" label
  * @property string $tabChildren Optional replacmenet for default "Children" label

--- a/wire/core/Template.php
+++ b/wire/core/Template.php
@@ -56,6 +56,7 @@
  * @property int $useCacheForUsers Use cache for: 0 = only guest users, 1 = guests and logged in users
  * @property int $cacheExpire Expire the cache for all pages when page using this template is saved? (1 = yes, 0 = no- only current page)
  * @property array $cacheExpirePages Array of Page IDs that should be expired, when cacheExpire == Template::cacheExpireSpecific
+ * @property array $cacheExpireSelector Selector string matching pages that should be expired, when cacheExpire == Template::cacheExpireSpecific
  * @property string $tags Optional tags that can group this template with others in the admin templates list 
  * @property string $tabContent Optional replacement for default "Content" label
  * @property string $tabChildren Optional replacmenet for default "Children" label
@@ -99,6 +100,12 @@ class Template extends WireData implements Saveable, Exportable {
 	 *
 	 */
 	const cacheExpireSpecific = 3; 
+
+	/**
+	 * Cache expiration options: expire page and pages matching a selector string (cacheExpireSelector)
+	 *
+	 */
+	const cacheExpireSelector = 4; 
 
 	/**
 	 * Cache expiration options: don't expire anything
@@ -187,6 +194,7 @@ class Template extends WireData implements Saveable, Exportable {
 		'useCacheForUsers' => 0, 	// use cache for: 0 = only guest users, 1 = guests and logged in users
 		'cacheExpire' => 0, 		// expire the cache for all pages when page using this template is saved? (1 = yes, 0 = no- only current page)
 		'cacheExpirePages' => array(),	// array of Page IDs that should be expired, when cacheExpire == Template::cacheExpireSpecific
+		'cacheExpireSelector' => '',	// selector string matching pages that should be expired, when cacheExpire == Template::cacheExpireSelector
 		'label' => '',			// label that describes what this template is for (optional)
 		'tags' => '',			// optional tags that can group this template with others in the admin templates list 
 		'modified' => 0, 		// last modified time for template or template file

--- a/wire/modules/PageRender.module
+++ b/wire/modules/PageRender.module
@@ -191,13 +191,16 @@ class PageRender extends WireData implements Module, ConfigurableModule {
 			$cacheFile->expireAll();
 			if($this->config->debug) $this->message("Expired page cache for entire site"); 
 
-		} else if($cacheExpire == Template::cacheExpireParents || $cacheExpire == Template::cacheExpireSpecific) { 
+		} else if($cacheExpire == Template::cacheExpireParents || $cacheExpire == Template::cacheExpireSpecific || $cacheExpire == Template::cacheExpireSelector) { 
 			// expire specific pages or parents
 
 			$selected = array();
 
 			if($cacheExpire == Template::cacheExpireParents) {
 				$selected = $page->parents; 
+
+			} else if($cacheExpire == Template::cacheExpireSelector && $page->template->cacheExpireSelector) {
+				$selected = $this->fuel('pages')->find($page->template->cacheExpireSelector);
 
 			} else if(is_array($page->template->cacheExpirePages) && count($page->template->cacheExpirePages)) {
 				$selected = $this->fuel('pages')->getById($page->template->cacheExpirePages); 				

--- a/wire/modules/Process/ProcessTemplate/ProcessTemplate.module
+++ b/wire/modules/Process/ProcessTemplate/ProcessTemplate.module
@@ -871,6 +871,7 @@ class ProcessTemplate extends Process {
 		$field->addOption(Template::cacheExpireSite, $this->_('Clear cache for entire site*')); // Clear cache for entire site // Note you should include the '*' to relate this item to the Cache expiration notes
 		$field->addOption(Template::cacheExpireParents, $this->_('Clear cache for the saved page and parents (including homepage)')); 
 		$field->addOption(Template::cacheExpireSpecific, $this->_('Clear cache for the saved page and other pages that I specify...')); 
+		$field->addOption(Template::cacheExpireSelector, $this->_('Clear cache for the saved page and other pages matching selector...')); 
 		$field->addOption(Template::cacheExpireNone, $this->_('Do nothing'));
 		$field->attr('value', (int) $template->cacheExpire); 
 		$field->notes = $this->_('*To maximize performance, cache files are all expired as a group rather than cleared individually.'); // Cache expiration notes // This explains the 'Clear cache for entire site*' option
@@ -886,6 +887,17 @@ class ProcessTemplate extends Process {
 		$value = is_array($template->cacheExpirePages) ? $template->cacheExpirePages : array();
 		$field->attr('value', $value);
 		$field->showIf = 'cache_time>0, cacheExpire=' . Template::cacheExpireSpecific;
+		$form->append($field); 
+
+		// --------------------
+
+		$field = $this->modules->get('InputfieldText'); 
+		$field->attr('name', 'cacheExpireSelector'); 
+		$field->label = $this->_('Custom selector to find the other pages that should have their cache cleared'); 
+		$field->description = $this->_('If you want to find pages using a ProcessWire selector rather than selecting each page individually (above) then enter the selector to find the pages. This selector will be passed to a $pages->find("your selector"); statement.'); // Description for Custom selector to find cache expire pages
+		$field->notes = $exampleLabel . $this->_('parent=/products/, template=product, sort=name'); // Example of Custom selector to find cache expire pages
+		$field->attr('value', $template->cacheExpireSelector); 
+		$field->showIf = 'cache_time>0, cacheExpire=' . Template::cacheExpireSelector;
 		$form->append($field); 
 
 		// --------------------
@@ -1696,6 +1708,9 @@ class ProcessTemplate extends Process {
 
 		if($this->template->cacheExpire == Template::cacheExpireSpecific) $this->template->cacheExpirePages = $form->get('cacheExpirePages')->value; 
 			else $this->template->cacheExpirePages = array();
+	
+		if($this->template->cacheExpire == Template::cacheExpireSelector) $this->template->cacheExpireSelector = $form->get('cacheExpireSelector')->value; 
+			else $this->template->cacheExpireSelector = '';
 	
 		// family
 	


### PR DESCRIPTION
[This recent forum post](https://processwire.com/talk/topic/8997-clear-cache-for-all-children/) got me thinking that it would be nice if page cache could be cleared for pages matching a selector. While definitely not as effective (in regards to time and resources spent clearing cache files) as clearing cache for entire site, it would allow really fine-grained workflow when necessary.

What do you think, does this make any sense at all? Better implementation could probably boost both performance and flexibility, if only the concept is sensible.

For the record, I'm already using this on my blog to clear specific page cache files when tags or blog posts are altered. Only other viable option would be clearing cache for entire site every time :)