### PR TITLE
Set a name on the "Selectable Pages" fieldset

### DIFF
--- a/wire/modules/Inputfield/InputfieldPage/InputfieldPage.module
+++ b/wire/modules/Inputfield/InputfieldPage/InputfieldPage.module
@@ -576,6 +576,7 @@ class InputfieldPage extends Inputfield implements ConfigurableModule {
 
 		$fieldset = wire('modules')->get('InputfieldFieldset'); 
 		$fieldset->label = $this->_('Selectable Pages');
+		$fieldset->setAttribute('name', 'selectable_pages');
 
 		$field = $this->modules->get('InputfieldPageListSelect');
 		$field->setAttribute('name', 'parent_id'); 


### PR DESCRIPTION
It would be useful to set a name on the "Selectable Pages" fieldset.

I have a field for which I need to be able to change the selectable pages for different template contexts, and to do this, I need to hook into InputfieldPage::getConfigAllowContext, and add the fieldset to the configurable fields. Unfortunately, since it doesn't have a name, it is not possible to add it.

As a temporary solution, I hooked into InputfieldPage::getConfigInputfields to add the name myself, but it seems pretty harmless to do it in the source code instead.