### PR TITLE
Don't treat URLs with non name-format characters in .htaccess

### DIFF
--- a/htaccess.txt
+++ b/htaccess.txt
@@ -139,16 +139,6 @@ DirectoryIndex index.php index.html index.htm
   # RewriteCond %{HTTP_HOST} !^www\. [NC]
   # RewriteRule ^ http://www.%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
 
-  # ----------------------------------------------------------------------------------------------- 
-  # OPTIONAL: Send URLs with non name-format characters to 404 page
-  # Remove this section if it interferes with URLs of any other software you may be running. 
-  # ----------------------------------------------------------------------------------------------- 
-
-  RewriteCond %{REQUEST_URI} "[^-_.a-zA-Z0-9/~]"
-  RewriteCond %{REQUEST_FILENAME} !-f
-  RewriteCond %{REQUEST_FILENAME} !-d
-  RewriteRule ^(.*)$ index.php?it=/http404/ [L,QSA]
-
   # -----------------------------------------------------------------------------------------------
   # Access Restrictions: Protect ProcessWire system files
   # -----------------------------------------------------------------------------------------------
@@ -181,12 +171,6 @@ DirectoryIndex index.php index.html index.htm
   RewriteCond %{REQUEST_URI} (^|/)site-default/
   # If any conditions above match, isssue a 403 forbidden
   RewriteRule ^.*$ - [F,L]
-
-  # ----------------------------------------------------------------------------------------------- 
-  # Ensure that the URL follows the name-format specification required by ProcessWire
-  # ----------------------------------------------------------------------------------------------- 
-
-  RewriteCond %{REQUEST_URI} "^/~?[-_.a-zA-Z0-9/]*$"
 
   # -----------------------------------------------------------------------------------------------
   # If the request is for a file or directory that physically exists on the server,


### PR DESCRIPTION
I've recently been working on the module [PagePathHistoryManager](https://processwire.com/talk/topic/9436-page-path-history-manager/). One of the main goals was to make it easy to record former URLs for pages that were imported from another CMS. In the particular project I was building this for, the legacy URLs contain non-ascii characters.

In this context I discovered that requests to URLs containing non-ascii characters are actually redirected using the Apache module `mod_rewrite` to the 404 page – and therefore before there's any possibility to handle it otherwise.

While the comments in the htaccess.txt file suggest that this behavior is optional and for sure the actual htaccess file in use should be modified to suit the needs of the given environment, I'm not really sure why this is included as a default in the first place.

I understand that it moves the burden of handling requests to URLs that don't fit the name-format from Processwire to Apache. Apart from that, these URLs are also [handled correctly](https://github.com/ryancramerdesign/ProcessWire/blob/b094a1ff6e71651b710425c10bc3e1d7c0aaf9c4/wire/modules/Process/ProcessPageView.module#L241) by `ProcessPageView` so there's no real need for this behavior. If I'm not mistaken, this makes it "just" a performance optimization. (saving one attempt to get an invalid URL). It might help with security only if something else is going seriously wrong, e.g. by hooking `ProcessPageView` and doing something silly in the hook.

On the other hands this prevents module authors from handling URLs including special characters in a custom manner, e.g. by mapping them to existing page URLs. I understand that this might not be a common need, but I would still hereby propose that these parts are removed (or commented out) in the default `htaccess.txt`. What do you think?