### PR TITLE
Implemented multi-language page name handling for PagePathHistory module

### DIFF
--- a/wire/modules/PagePathHistory.module
+++ b/wire/modules/PagePathHistory.module
@@ -4,220 +4,366 @@
  * ProcessWire Page Path History
  *
  * Keeps track of past URLs where pages have lived and automatically 301 redirects
- * to the new location whenever the past URL is accessed. 
+ * to the new location whenever the past URL is accessed.
  *
- * 
- * ProcessWire 2.x 
- * Copyright (C) 2014 by Ryan Cramer 
+ *
+ * ProcessWire 2.x
+ * Copyright (C) 2014 by Ryan Cramer
  * Licensed under GNU/GPL v2, see LICENSE.TXT
- * 
+ *
  * http://processwire.com
- * 
+ *
  *
  */
 
 class PagePathHistory extends WireData implements Module {
 
-	public static function getModuleInfo() {
-		return array(
-			'title' => 'Page Path History', 
-			'version' => 1, 
-			'summary' => "Keeps track of past URLs where pages have lived and automatically redirects (301 permament) to the new location whenever the past URL is accessed.",
-			'singular' => true, 
-			'autoload' => true, 
-			);
-	}
+    public static function getModuleInfo() {
+        return array(
+            'title' => 'Page Path History',
+            'version' => 1,
+            'summary' => "Keeps track of past URLs where pages have lived and automatically redirects (301 permanent) to the new location whenever the past URL is accessed. Handles multilanguage pagenames.",
+            'singular' => true,
+            'autoload' => true,
+        );
+    }
 
-	/**
-	 * Table created by this module
-	 *
-	 */
-	const dbTableName = 'page_path_history';
+    /**
+     * Table created by this module
+     *
+     */
+    const dbTableName = 'page_path_history';
 
-	/**
-	 * Minimum age in seconds that a page must be before we'll bother remembering it's previous path
-	 *
-	 */
-	const minimumAge = 120; 
+    /**
+     * Minimum age in seconds that a page must be before we'll bother remembering it's previous path
+     *
+     */
+    const minimumAge = 120;
 
-	/**
-	 * Maximum segments to support in a redirect URL
-	 *
-	 * Used to place a limit on recursion and paths
-	 *
-	 */
-	const maxSegments = 10; 
+    /**
+     * Maximum segments to support in a redirect URL
+     *
+     * Used to place a limit on recursion and paths
+     *
+     */
+    const maxSegments = 10;
+
+    /**
+     * @var bool True if multilanguage page name support is active
+     */
+    protected $isMultilanguage;
+
+    /**
+     * @var string The path that was requested, before any processing
+     */
+    protected $requestPath = '';
+
+    /**
+     * Initialize the hooks
+     *
+     */
+    public function init() {
+        $this->addHookBefore('ProcessPageView::execute', $this, 'hookProcessPageViewExecute', array('priority' => 90));
+        $this->pages->addHook('moved', $this, 'hookPageMoved');
+        $this->pages->addHook('renamed', $this, 'hookPageMoved');
+        $this->pages->addHook('deleted', $this, 'hookPageDeleted');
+        $this->addHook('ProcessPageView::pageNotFound', $this, 'hookPageNotFound');
+    }
+
+    /**
+     * Initialize the multilanguage specific hooks
+     */
+    public function ready() {
+        $this->isMultilanguage = $this->modules->isInstalled('LanguageSupportPageNames') &&
+            count(wire('languages'));
+        if ($this->isMultilanguage) {
+            $this->addHookAfter('Page::loaded', $this, 'hookPageLoaded');
+            $this->addHookAfter('Pages::saveReady', $this, 'hookPageSaveReady');
+            $this->addHookAfter('Pages::saved', $this, 'hookPageSaved');
+        }
+    }
+
+    public function hookProcessPageViewExecute(HookEvent $event) {
+        // Save now, since ProcessPageView removes $_GET['it'] when it executes
+        $it = isset($_GET['it']) ? $_GET['it'] : '';
+
+        // Add leading slash if missing
+        if ('/' !== substr($it, 0, 1)) {
+            $it = "/{$it}";
+        }
+
+        $this->requestPath = $it;
+    }
+
+    public function hookPageLoaded(HookEvent $event) {
+        $page = $event->object;
+        $pageId = $page->id;
+
+        // Return if page has already been processed or is admin page
+        if ($page->namePreviousLanguage || 'admin' === $page->template) {
+            return;
+        }
+
+        // Add all page name language versions to $page->namePreviousLanguage
+        $languages = $this->wire('languages');
+        $languageNames = array();
+        foreach ($languages as $language) {
+            if ($language->isDefault()) {
+                continue;
+            }
+            $languageNames[$language->id] = $page->localName($language);
+        }
+        $page->namePreviousLanguage = $languageNames;
+    }
+
+    public function hookPageSaveReady(HookEvent $event) {
+        $page = $event->arguments[0];
+        $pageId = $page->id;
+
+        if (empty($page->namePreviousLanguage) || 'admin' === $page->template) {
+            return;
+        }
+
+        // Remove all unchanged language names from $page->namePreviousLanguage
+        $languages = $this->wire('languages');
+        $languageNames = $page->namePreviousLanguage;
+        foreach($languages as $language) {
+            if ($language->isDefault() || empty($languageNames[$language->id])) {
+                continue;
+            }
+            $currentName = $page->localName($language);
+            $previousName = $languageNames[$language->id];
+            if ($currentName === $previousName) {
+                unset($languageNames[$language->id]);
+            }
+        }
+        $page->namePreviousLanguage = $languageNames;
+    }
+
+    /**
+     * Trigger hookPageMoved after save if not moved or renamed in primary language.
+     * @param HookEvent $event
+     */
+    public function hookPageSaved(HookEvent $event) {
+        $page = $event->arguments[0];
+        $changes = $event->arguments[1];
+
+        // No need to do anything if page is renamed or moved anyway
+        $renamed = $page->namePrevious && ($page->namePrevious !== $page->name);
+        $moved = (bool) $page->parentPrevious;
+        if ($renamed || $moved) {
+            return;
+        }
+
+        // Trigger hook manually if name was changed in any language
+        $nameLanguageChanged = false;
+        $languages = wire('languages');
+        foreach ($languages as $language) {
+            if ($language->isDefault()) {
+                continue;
+            }
+            $fieldName = "name{$language->id}";
+            if (in_array($fieldName, $changes)) {
+                $nameLanguageChanged = true;
+                break;
+            }
+        }
+
+        if ($nameLanguageChanged) {
+            $this->hookPageMoved($event);
+        }
+    }
+
+    /**
+     * Hook called when a page is moved or renamed
+     *
+     */
+    public function hookPageMoved(HookEvent $event) {
+
+        $page = $event->arguments[0];
+        if($page->template == 'admin') return;
+        $age = time() - $page->created;
+        if($age < self::minimumAge) return;
+
+        if($page->parentPrevious) {
+            // if former or current parent is in trash, then don't bother saving redirects
+            if($page->parentPrevious->isTrash() || $page->parent->isTrash()) return;
+
+            // the start of our redirect URL will be the previous parent's URL
+            $parentPage = $page->parentPrevious;
+        } else {
+            // the start of our redirect URL will be the current parent's URL (i.e. name changed)
+            $parentPage = $page->parent;
+        }
+
+        $paths = array();
+        $currentPaths = array();
+
+        // Process default language page name
+        $pageName = $page->namePrevious ?
+            $page->namePrevious :
+            $page->name;
+        $pastPath = $parentPage->path . $pageName;
+        $currentPath = $page->path;
+        if ($currentPath !== $pastPath) {
+            $paths[] = $pastPath;
+            $currentPaths[] = $currentPath;
+        }
+
+        // Process language page names
+        if ($this->isMultilanguage) {
+            $languages = wire('languages');
+            /* @var LanguageSupportPageNames $languagePageNames */
+            $languagePageNames = $this->modules->get('LanguageSupportPageNames');
+            foreach ($languages as $language) {
+                if ($language->isDefault()) {
+                    continue;
+                }
+                $parentPagePath = $parentPage->localPath($language);
+                $pageName = !empty($page->namePreviousLanguage[$language->id]) ?
+                    $page->namePreviousLanguage[$language->id] :
+                    $page->localName($language);
+
+                $pastPath = $parentPagePath . $pageName;
+                $currentPath = $page->localPath($language);
+                if ($currentPath !== $pastPath) {
+                    // Remove language prefix from path
+                    $paths[] = $pastPath;
+                    $currentPaths[] = $currentPath;
+                }
+            }
+        }
 
 
-	/**
-	 * Initialize the hooks
-	 *
-	 */
-	public function init() {
-		$this->pages->addHook('moved', $this, 'hookPageMoved'); 
-		$this->pages->addHook('renamed', $this, 'hookPageMoved'); 
-		$this->pages->addHook('deleted', $this, 'hookPageDeleted');
-		$this->addHook('ProcessPageView::pageNotFound', $this, 'hookPageNotFound'); 
-	}
+        /* @var WireDatabasePDO $database
+         * @var PDOStatement $query */
+        $database = $this->wire('database');
+        $query = $database->prepare("INSERT INTO " . self::dbTableName . " SET path=:path, pages_id=:pages_id, created=NOW()");
 
-	/**
-	 * Hook called when a page is moved or renamed
-	 *
-	 */
-	public function hookPageMoved(HookEvent $event) {
+        // Insert all past paths
+        foreach ($paths as $path) {
+            $query->bindValue(":path", $path);
+            $query->bindValue(":pages_id", $page->id, PDO::PARAM_INT);
+            try {
+                $query->execute();
+            } catch(Exception $e) {
+                // catch the exception because it means there is already a past URL (duplicate)
+            }
+        }
 
-		$page = $event->arguments[0];
-		if($page->template == 'admin') return;
-		$age = time() - $page->created; 
-		if($age < self::minimumAge) return;
+        // delete any possible entries that overlap with the $page since are no longer applicable
+        $query = $database->prepare("DELETE FROM " . self::dbTableName . " WHERE path=:path LIMIT 1");
+        foreach ($currentPaths as $path) {
+            $query->bindValue(":path", rtrim($path, '/'));
+            $query->execute();
+        }
+    }
 
-		// note that the paths we store have no trailing slash
+    /**
+     * Hook called upon 404 from ProcessPageView::pageNotFound
+     *
+     */
+    public function hookPageNotFound(HookEvent $event) {
 
-		if(!$page->namePrevious) {
-			// abort saving a former URL if it looks like there isn't going to be one
-			if(!$page->parentPrevious || $page->parentPrevious->id == $page->parent->id) return;
-		}
+        $page = $event->arguments[0];
 
-		if($page->parentPrevious) {
+        // If there is a page object set, then it means the 404 was triggered
+        // by the user not having access to it, or by the $page's template
+        // throwing a 404 exception. In either case, we don't want to do a
+        // redirect if there is a $page since any 404 is intentional there.
+        if($page && $page->id) return;
 
-			// if former or current parent is in trash, then don't bother saving redirects
-			if($page->parentPrevious->isTrash() || $page->parent->isTrash()) return; 
+        $path = $this->requestPath;
+        $page = $this->getPage($path);
 
-			// the start of our redirect URL will be the previous parent's URL
-			$path = $page->parentPrevious->path;
+        if($page->id && $page->viewable()) {
+            // if a page was found, redirect to it
+            $this->session->redirect($page->url);
+        }
 
-		} else {
-			// the start of our redirect URL will be the current parent's URL (i.e. name changed)
-			$path = $page->parent->path;
-		}
+    }
 
-		if($page->namePrevious) $path .= $page->namePrevious; 
-			else $path .= $page->name; 
+    /**
+     * Given a previously existing path, return the matching Page object or NullPage if not found.
+     *
+     * @param string $path Historical path of page you want to retrieve
+     * @param int $level Recursion level for internal recursive use only
+     * @return Page|NullPage
+     *
+     */
+    protected function getPage($path, $level = 0) {
 
+        $page = new NullPage();
+        $pathRemoved = '';
+        $path = rtrim($path, '/');
+        $cnt = 0;
+        /* @var Database $database */
+        $database = $this->wire('database');
 
-		$database = $this->wire('database');	
-	
-		$query = $database->prepare("INSERT INTO " . self::dbTableName . " SET path=:path, pages_id=:pages_id, created=NOW()");
-		$query->bindValue(":path", $path); 
-		$query->bindValue(":pages_id", $page->id, PDO::PARAM_INT);
+        while(strlen($path) && !$page->id && $cnt < self::maxSegments) {
 
-		try {
-			$query->execute();
+            $query = $database->prepare("SELECT pages_id FROM " . self::dbTableName . " WHERE path=:path");
+            $query->bindValue(":path", $path);
+            $query->execute();
+            if($query->rowCount() > 0) {
+                $pages_id = $query->fetchColumn();
+                $page = $this->pages->get((int) $pages_id);
+            } else {
+                $pos = strrpos($path, '/');
+                $pathRemoved = substr($path, $pos) . $pathRemoved;
+                $path = substr($path, 0, $pos);
+            }
+            $query->closeCursor();
 
-		} catch(Exception $e) {
-			// catch the exception because it means there is already a past URL (duplicate)
-		}
+            $cnt++;
+        }
 
-		// delete any possible entries that overlap with the $page since are no longer applicable
-		$query = $database->prepare("DELETE FROM " . self::dbTableName . " WHERE path=:path LIMIT 1");
-		$query->bindValue(":path", rtrim($page->path, '/'));
-		$query->execute();
-	}
+        // if no page was found, then we can stop trying now
+        if(!$page->id) return $page;
 
-	/**
-	 * Hook called upon 404 from ProcessPageView::pageNotFound
-	 *
-	 */
-	public function hookPageNotFound(HookEvent $event) {
-		
-		$page = $event->arguments[0]; 
+        if($cnt > 1) {
+            // a parent match was found if our counter is > 1
+            $parent = $page;
+            // use the new parent path and add the removed components back on to it
+            $path = rtrim($parent->path, '/') . $pathRemoved;
+            // see if it might exist at the new parent's URL
+            $page = $this->pages->get($path);
+            // if not, then go recursive, trying again
+            if(!$page->id && $level < self::maxSegments) $page = $this->getPage($path, $level+1);
+        }
 
-		// If there is a page object set, then it means the 404 was triggered
-		// by the user not having access to it, or by the $page's template 
-		// throwing a 404 exception. In either case, we don't want to do a 
-		// redirect if there is a $page since any 404 is intentional there.
-		if($page && $page->id) return; 
+        return $page;
+    }
 
-		$path = $event->arguments[1];
-		$page = $this->getPage($path);
+    /**
+     * When a page is deleted, remove it from our redirects list as well
+     *
+     */
+    public function hookPageDeleted(HookEvent $event) {
+        $page = $event->arguments[0];
+        $database = $this->wire('database');
+        $query = $database->prepare("DELETE FROM " . self::dbTableName . " WHERE pages_id=:pages_id");
+        $query->bindValue(":pages_id", $page->id, PDO::PARAM_INT);
+        $query->execute();
+    }
 
-		if($page->id && $page->viewable()) {
-			// if a page was found, redirect to it
-			$this->session->redirect($page->url);
-		}
-		
-	}
+    public function ___install() {
 
-	/**
-	 * Given a previously existing path, return the matching Page object or NullPage if not found.
-	 *
-	 * @param string $path Historical path of page you want to retrieve
-	 * @param int $level Recursion level for internal recursive use only
-	 * @return Page|NullPage
-	 *
-	 */
-	protected function getPage($path, $level = 0) {
+        $sql = 	"CREATE TABLE " . self::dbTableName . " (" .
+            "path VARCHAR(255) NOT NULL, " .
+            "pages_id INT UNSIGNED NOT NULL, " .
+            "created TIMESTAMP NOT NULL, " .
+            "PRIMARY KEY path (path), " .
+            "INDEX pages_id (pages_id), " .
+            "INDEX created (created) " .
+            ") ENGINE={$this->config->dbEngine} DEFAULT CHARSET={$this->config->dbCharset}";
 
-		$page = new NullPage();
-		$pathRemoved = '';
-		$path = rtrim($path, '/');
-		$cnt = 0;
-		$database = $this->wire('database');
+        $this->wire('database')->exec($sql);
 
-		while(strlen($path) && !$page->id && $cnt < self::maxSegments) {
+    }
 
-			$query = $database->prepare("SELECT pages_id FROM " . self::dbTableName . " WHERE path=:path");
-			$query->bindValue(":path", $path); 
-			$query->execute();
-			if($query->rowCount() > 0) {
-				$pages_id = $query->fetchColumn();
-				$page = $this->pages->get((int) $pages_id);
-			} else {
-				$pos = strrpos($path, '/');
-				$pathRemoved = substr($path, $pos) . $pathRemoved;
-				$path = substr($path, 0, $pos);
-			}
-			$query->closeCursor();
-				
-			$cnt++;
-		} 
-
-		// if no page was found, then we can stop trying now
-		if(!$page->id) return $page; 
-
-		if($cnt > 1) {
-			// a parent match was found if our counter is > 1
-			$parent = $page; 
-			// use the new parent path and add the removed components back on to it
-			$path = rtrim($parent->path, '/') . $pathRemoved; 
-			// see if it might exist at the new parent's URL
-			$page = $this->pages->get($path); 
-			// if not, then go recursive, trying again
-			if(!$page->id && $level < self::maxSegments) $page = $this->getPage($path, $level+1); 
-		}
-	
-		return $page; 	
-	}
-
-	/**
-	 * When a page is deleted, remove it from our redirects list as well
-	 *
-	 */
-	public function hookPageDeleted(HookEvent $event) {
-		$page = $event->arguments[0];
-		$database = $this->wire('database');
-		$query = $database->prepare("DELETE FROM " . self::dbTableName . " WHERE pages_id=:pages_id"); 
-		$query->bindValue(":pages_id", $page->id, PDO::PARAM_INT);
-		$query->execute();
-	}
-
-	public function ___install() {
-
-		$sql = 	"CREATE TABLE " . self::dbTableName . " (" . 
-				"path VARCHAR(255) NOT NULL, " . 
-				"pages_id INT UNSIGNED NOT NULL, " . 
-				"created TIMESTAMP NOT NULL, " . 
-				"PRIMARY KEY path (path), " . 
-				"INDEX pages_id (pages_id), " . 
-				"INDEX created (created) " . 
-				") ENGINE={$this->config->dbEngine} DEFAULT CHARSET={$this->config->dbCharset}";
-
-		$this->wire('database')->exec($sql); 
-
-	}
-
-	public function ___uninstall() {
-		$this->wire('database')->query("DROP TABLE " . self::dbTableName); 
-	}
+    public function ___uninstall() {
+        $this->wire('database')->query("DROP TABLE " . self::dbTableName);
+    }
 
 }


### PR DESCRIPTION
The core module `PagePathHistory` didn't handle [multi-language URLs/page names](http://processwire.com/api/multi-language-support/multi-language-urls/) implemented by the core module `LanguageSupportPageNames` until now. I [already described this](https://processwire.com/talk/topic/9342-pagepathhistory-with-multi-language-page-names/) in greater detail in the forum.

This patch adds language-awareness for  `PagePathHistory`.