### PR TITLE
Allow to comment out lines toolbar setting

### DIFF
--- a/wire/modules/Inputfield/InputfieldCKEditor/InputfieldCKEditor.module
+++ b/wire/modules/Inputfield/InputfieldCKEditor/InputfieldCKEditor.module
@@ -152,6 +152,7 @@ class InputfieldCKEditor extends InputfieldTextarea {
 	 *
 	 * Toolbar items split by commas
 	 * Groups of toolbar items split by lines
+	 * Toolbar that starts with '#' is ignored
 	 *
 	 */
 	protected function toolbarStringToArray($str) {
@@ -160,7 +161,9 @@ class InputfieldCKEditor extends InputfieldTextarea {
 		$lines = explode("\n", $str); 
 		foreach($lines as $line) {
 			$line = trim($line);
-			if(empty($line)) {
+			if (strpos($line, '#') === 0) {
+				continue;
+			} elseif(empty($line)) {
 				$items[] = '/';
 			} else {
 				$lineArray = explode(',', $line); 
@@ -601,7 +604,7 @@ class InputfieldCKEditor extends InputfieldTextarea {
 		$f->attr('name', 'toolbar'); 
 		$f->attr('value', $this->toolbar);
 		$f->label = $this->_('CKEditor Toolbar'); 
-		$f->description = $this->_('Separate each toolbar item with a comma. Group items by placing them on the same line and use a hyphen "-" where you want a separator to appear within a group. If you want more than one toolbar row, separate each row with a blank line.'); // Toolbar options description
+		$f->description = $this->_('Separate each toolbar item with a comma. Group items by placing them on the same line and use a hyphen "-" where you want a separator to appear within a group. If you want more than one toolbar row, separate each row with a blank line. Insert a hash '#' at the beginning of a line if you want it to be ignored.'); // Toolbar options description
 		$wrapper->add($f); 
 
 		$purifierInstalled = wire('modules')->isInstalled('MarkupHTMLPurifier'); 


### PR DESCRIPTION
This change would allow people to "comment out" lines in the toolbar setting by inserting a # at the beginning.