### PR TITLE
Fixed infinite loop when a page is assigned a child page as its own parent

### DIFF
--- a/wire/core/Page.php
+++ b/wire/core/Page.php
@@ -961,7 +961,9 @@ class Page extends WireData implements Countable {
 	 */
 	protected function setParent(Page $parent) {
 		if($this->parent && $this->parent->id == $parent->id) return $this; 
-		if($parent->id && $this->id == $parent->id) throw new WireException("Page cannot be its own parent"); 
+		if($parent->id && $this->id == $parent->id || $parent->parents->has($this)) {
+            throw new WireException("Page cannot be its own parent");
+        }
 		$this->trackChange('parent', $this->parent, $parent);
 		if(($this->parent && $this->parent->id) && $this->parent->id != $parent->id) {
 			if($this->settings['status'] & Page::statusSystem) throw new WireException("Parent changes are disallowed on this page"); 


### PR DESCRIPTION
When setting the new parent for a page, there is no validation whether the new parent is actually a child of the current page. This operation wouldn't make sense at all and considering the current implementation of [`PageTraversal::parents()`](https://github.com/ryancramerdesign/ProcessWire/blob/6e470e6fa0346f737d50268b0816faaec11196cf/wire/core/PageTraversal.php#L110) leads to an infinite loop. When used in a common setting, i.e. with Apache and mod_php, program execution fails when running into a timeout.

    Error: Maximum execution time of 30 seconds exceeded (line 596 of /var/www/dev/pwdev/wire/core/Page.php)

The patch simply adds a check and throws an Exception to resolve the problem. The handling is the same as when it is attempted to set a page to be it's own parent.