### PR TITLE
Basic error handling for PageList AJAX requests

### DIFF
--- a/wire/modules/Process/ProcessPageList/ProcessPageList.js
+++ b/wire/modules/Process/ProcessPageList/ProcessPageList.js
@@ -400,7 +400,16 @@ $(document).ready(function() {
 				}; 
 
 				if(!replace) $target.append($loading.show()); 
-				$.getJSON(options.ajaxURL + "?id=" + id + "&render=JSON&start=" + start + "&lang=" + options.langID + "&open=" + options.openPageIDs[0] + "&mode=" + options.mode, processChildren); 
+				$.getJSON(options.ajaxURL + "?id=" + id + "&render=JSON&start=" + start + "&lang=" + options.langID + "&open=" + options.openPageIDs[0] + "&mode=" + options.mode)
+					.done(function(data, textStatus, jqXHR) {
+						processChildren(data);
+					})
+					.fail(function(jqXHR, textStatus, errorThrown) {
+						processChildren({
+							error: 1,
+							message: !jqXHR.status ? options.ajaxNetworkError : options.ajaxUnknownError
+						});
+					});
 			}
 
 			/**

--- a/wire/modules/Process/ProcessPageList/ProcessPageList.module
+++ b/wire/modules/Process/ProcessPageList/ProcessPageList.module
@@ -41,7 +41,7 @@ class ProcessPageList extends Process implements ConfigurableModule {
 		return array(
 			'title' => 'Page List',          
 			'summary' => 'List pages in a hierarchal tree structure', 
-			'version' => 109, 
+			'version' => '1.0.10',
 			'permanent' => true, 
 			'permission' => 'page-edit',
 			'icon' => 'sitemap',
@@ -131,6 +131,8 @@ class ProcessPageList extends Process implements ConfigurableModule {
 				'containerID' => 'PageListContainer', 
 				'ajaxURL' => $this->config->urls->admin . "page/list/", 
 				'ajaxMoveURL' => $this->config->urls->admin . "page/sort/",
+				'ajaxNetworkError' => $this->_('Network error, please try again later!'), // Network error during AJAX request
+				'ajaxUnknownError' => $this->_('Unknown error, please try again later!'), // Unknown error during AJAX request
 				'rootPageID' => $this->id, 
 				'openPageIDs' => $openPageIDs, 
 				'openPagination' => (int) $this->input->get->n, // @todo: make it openPaginations and correspond to openPageIDs


### PR DESCRIPTION
This pull request introduces basic error handling for ProcessPageList AJAX requests, and mainly aims to inform the user of two types of errors: "network error" and "unknown error", the latter of which includes everything other than obvious network issues (server-side 5xx errors etc.)

This addition has two main benefits:

- Informing the user that something went wrong instead of endless "loading animation"
- Displaying page edit icons and ending the loading part, so that one can retry the requests without reloading the whole page

This is mostly useful when the error occurs while opening sub-trees, since during initial page load this just outputs an error message and leaves it at that. In that case a page reload is required anyway.

I've been traveling quite a bit lately, and having to rely on bad connections has made the need for better AJAX error handling obvious. When you're on a slow and/or unstable connection, the initial page load may take a very long time, and if each failed AJAX request further down the tree means I have to redo the whole process, that's a bit too much.

Additionally this could help tracking down certain types of obscure issues, such as a module causing page tree not to open properly under specific circumstances. Earlier this would've resulted in endless loading animation (which could've meant anything); now a message is displayed instead, hopefully making tracking such issues easier.

For the record, I did consider redoing the request on network error (similar to how some web apps, like Trello, behave) but that didn't seem necessary here -- and either way, once there's a basic feature in place, it's easier to develop it further if such a need arises.