### PR TITLE
Add an array of general-purpose HTTP status codes to WireHttp

### DIFF
--- a/wire/core/WireHttp.php
+++ b/wire/core/WireHttp.php
@@ -56,6 +56,40 @@ class WireHttp extends Wire {
 	protected $headers = array();
 
 	/**
+	 * HTTP status codes
+	 * 
+	 * Note: error codes are defined separately and merged into status codes
+	 * in constructor method.
+	 * 
+	 * @var array
+	 * 
+	 */
+	protected $statusCodes = array(
+		100 => 'Continue',
+		101 => 'Switching Protocols',
+		102 => 'Processing (WebDAV; RFC 2518)',
+		200 => 'OK',
+		201 => 'Created',
+		202 => 'Accepted',
+		203 => 'Non-Authoritative Information',
+		204 => 'No Content',
+		205 => 'Reset Content',
+		206 => 'Partial Content',
+		207 => 'Multi-Status (WebDAV; RFC 4918)',
+		208 => 'Already Reported (WebDAV; RFC 5842)',
+		226 => 'IM Used (RFC 3229)',
+		300 => 'Multiple Choices',
+		301 => 'Moved Permanently',
+		302 => 'Found',
+		303 => 'See Other',
+		304 => 'Not Modified',
+		305 => 'Use Proxy',
+		306 => 'Switch Proxy',
+		307 => 'Temporary Redirect',
+		308 => 'Permanent Redirect (RFC 7238)',
+		);
+
+	/**
 	 * HTTP error codes
 	 * 
 	 * @var array
@@ -202,6 +236,7 @@ class WireHttp extends Wire {
 	public function __construct() {
 		$this->hasCURL = function_exists('curl_init') && !ini_get('safe_mode') && !ini_get('open_basedir');
 		$this->hasFopen = ini_get('allow_url_fopen');
+		$this->statusCodes = array_merge($this->statusCodes, $this->errorCodes);
 		$this->resetRequest();
 		$this->resetResponse();
 	}
@@ -849,6 +884,27 @@ class WireHttp extends Wire {
 	 */
 	public function getErrorCodes() {
 		return $this->errorCodes;
+	}
+
+	/**
+	 * Return array of all possible HTTP status codes as (code => description)
+	 * 
+	 * @return array
+	 * 
+	 */
+	public function getStatusCodes() {
+		return $this->statusCodes;
+	}
+
+	/**
+	 * Return description for one HTTP status code
+	 * 
+	 * @param int
+	 * @return string|null
+	 * 
+	 */
+	public function getStatusText($code) {
+		return isset($this->statusCodes[$code]) ? $this->statusCodes[$code] : null;
 	}
 
 	/**

--- a/wire/core/WireHttp.php
+++ b/wire/core/WireHttp.php
@@ -236,7 +236,7 @@ class WireHttp extends Wire {
 	public function __construct() {
 		$this->hasCURL = function_exists('curl_init') && !ini_get('safe_mode') && !ini_get('open_basedir');
 		$this->hasFopen = ini_get('allow_url_fopen');
-		$this->statusCodes = array_merge($this->statusCodes, $this->errorCodes);
+		$this->statusCodes = $this->statusCodes + $this->errorCodes;
 		$this->resetRequest();
 		$this->resetResponse();
 	}


### PR DESCRIPTION
This PR adds an array of general-purpose HTTP status codes to WireHttp, as well as new methods for getting all codes (getStatusCodes) and text description for any single code (getStatusText).

While building modules, site features, etc. which perform HTTP requests I've been including a list of status codes on a case-by-case basis over and over again. With WireHttp already containing a list of error codes, it doesn't seem like too much of a stretch for it to contain a list of other status codes too.

In order to not break backwards compatibility (or make any unnecessary rewrites) I ended up adding the statusCodes array as a separate entity, and combining it with errorCodes in __construct() with the array union operator.
