### PR TITLE
ImageSizer: detect unlimited PHP memory setting

### DIFF
--- a/wire/core/ImageSizer.php
+++ b/wire/core/ImageSizer.php
@@ -1823,6 +1823,7 @@ class ImageSizer extends Wire {
 		}
 
 		if($phpMaxMem <= 0) return null; // we couldn't read the MaxMemorySetting or there isn't one set, so in both cases we do not know if there is enough or not
+        if($phpMaxMem === -1) return true; // there is no memory limit configured
 
 		// calculate $sourceDimensions
 		if(!isset($sourceDimensions[0]) || !isset($sourceDimensions[1]) || !isset($sourceDimensions[2]) || !is_int($sourceDimensions[0]) || !is_int($sourceDimensions[1]) || !is_int($sourceDimensions[2])) return null;

--- a/wire/core/ImageSizer.php
+++ b/wire/core/ImageSizer.php
@@ -1822,8 +1822,8 @@ class ImageSizer extends Wire {
 			}
 		}
 
+        if($phpMaxMem === -1) return true; // memory explicitly set to unlimited
 		if($phpMaxMem <= 0) return null; // we couldn't read the MaxMemorySetting or there isn't one set, so in both cases we do not know if there is enough or not
-        if($phpMaxMem === -1) return true; // there is no memory limit configured
 
 		// calculate $sourceDimensions
 		if(!isset($sourceDimensions[0]) || !isset($sourceDimensions[1]) || !isset($sourceDimensions[2]) || !is_int($sourceDimensions[0]) || !is_int($sourceDimensions[1]) || !is_int($sourceDimensions[2])) return null;


### PR DESCRIPTION
ImageSizer doesn't handle unlimited setting (value `-1`) for the PHP setting `memory_limit` ([documentation]( http://php.net/manual/en/ini.core.php#ini.sect.resource-limits)) correctly. This leads to an error where PHP does throw an error about not enough memory for image operations while in fact, it already is unlimited. The patch fixes this behaviour.