### PR TITLE
add a ping() function

### DIFF
--- a/wire/core/WireDatabasePDO.php
+++ b/wire/core/WireDatabasePDO.php
@@ -319,6 +319,21 @@ class WireDatabasePDO extends Wire implements WireDatabase {
 	public function closeConnection() {
 		$this->pdo = null;
 	}
+        
+        /**
+         * Tries to query the db and if it fails tries to reconnect
+         * @return boolean
+         */
+        public function ping() {
+            try {
+                $this->pdo->query('SELECT 1');
+            } catch (PDOException $e) {
+                //force reconnect
+                $this->closeConnection();
+                $this->pdo();
+            }
+            return true;
+        }
 
 	/**
 	 * Retrieve new instance of WireDatabaseBackups ready to use with this connection
@@ -346,3 +361,4 @@ class WireDatabasePDO extends Wire implements WireDatabase {
 	}
 
 }
+


### PR DESCRIPTION
I have had timout trouble with long running backup jobs (s. https://processwire.com/talk/topic/9655-pre-release-remote-backup/) and missed a ping function on the db. 

So maybe this would be nice to have.

The function checks if the connection is alive, else invalidates it and tries to reconnect.