### PR TITLE
Add getter and update functions to AdminDataTable

### DIFF
--- a/wire/modules/Markup/MarkupAdminDataTable/MarkupAdminDataTable.module
+++ b/wire/modules/Markup/MarkupAdminDataTable/MarkupAdminDataTable.module
@@ -63,6 +63,15 @@ class MarkupAdminDataTable extends ModuleJS {
 		}
 		return $row;
 	}
+	
+	public function updateRow($key, array $a) {
+		$this->rows[$key] = $this->setupRow($a);
+		return $this;
+	}
+	
+	public function getRows() {
+		return $this->rows;
+	}
 
 	public function action(array $action) {
 		foreach($action as $label => $url) { 


### PR DESCRIPTION
I needed to hook into an admin data table (ProcessFormBuilder::buildListEntries) and recognized that there is no way to get the rows or edit them. So I added it. 

Here is a sample on how I'm using it:

```
public function init() {
    $this->addHookAfter("ProcessFormBuilder::buildListEntries", $this, "hookFunction");
}

public function hookFunction(HookEvent $e) {
    foreach($e->return->getRows() as $key => $row) {
        $row[3] = "Updated content";
        $e->return->updateRow($key, $row);
    }
}
```
