### PR TITLE
Added ability to use the email address when doing a reset password reque...

### DIFF
--- a/wire/modules/Process/ProcessForgotPassword.module
+++ b/wire/modules/Process/ProcessForgotPassword.module
@@ -102,7 +102,7 @@ class ProcessForgotPassword extends Process implements ConfigurableModule {
 		$field = $this->modules->get("InputfieldText"); 	
 		$field->attr('id+name', 'username');
 		$field->required = true; 
-		$field->label = $this->_("Enter your user name");
+		$field->label = $this->_("Enter your user name or email");
 		$field->description = $this->_("If you have an account in our system with a valid email address on file, an email will be sent to you after you submit this form. That email will contain a link that you may click on to reset your password.");
 		$form->add($field);
 	
@@ -139,6 +139,16 @@ class ProcessForgotPassword extends Process implements ConfigurableModule {
 			if($user && $user->id && $user->email && !$user->isUnpublished()) {
 				// user was found, send them an email with reset link
 				$this->step2_sendEmail($user);
+			}
+			else {
+				// try also with the email address
+				$email = $this->sanitizer->email( $this->input->post->username );
+				if ( strlen( $email ) ) {
+					$user = $this->users->get( "email=$email" );
+					if ( $user && $user->id && $user->email == $email && !$user->isUnpublished() ) {
+						$this->step2_sendEmail( $user );
+					}
+				}
 			}
 		}
 
@@ -223,6 +233,9 @@ class ProcessForgotPassword extends Process implements ConfigurableModule {
 				$this->error("Unable to complete this step"); 
 				return;
 			}
+		}
+		else {
+			$this->logError('Error in '.__CLASS__.'::'.__FUNCTION__.' : Problems sending password reset email to '.$user->email);
 		}
 	}
 
@@ -403,6 +416,4 @@ class ProcessForgotPassword extends Process implements ConfigurableModule {
 		return $form; 
 	}
 
-
 }
-


### PR DESCRIPTION
This changes can be useful to let the user enter his/her email address when requesting a password reset. In our scenario, for example, the user name is dynamically generated (with an hashed and unique code) and for that reason the user only needs to enter her/his email address.
Hope this can be safely integrated.