### PR TITLE
Adjusts to the rendering of the page tree if a custom root node is selected

### DIFF
--- a/wire/modules/Process/ProcessPageAdd/ProcessPageAdd.module
+++ b/wire/modules/Process/ProcessPageAdd/ProcessPageAdd.module
@@ -588,7 +588,7 @@ class ProcessPageAdd extends Process implements ConfigurableModule, WirePageEdit
 			// if not specified in get variable, next check parent template for setting
 			$nameFormat = $nameFormatTemplate;
 		}
-		$class = $template->pageClass ? $page->template->pageClass : 'Page';
+		$class = $template->pageClass ? $template->pageClass : 'Page';
 		$page = new $class(); 
 		$page->template = $template;	
 		$page->parent = $parent; 

--- a/wire/modules/Process/ProcessPageList/ProcessPageList.module
+++ b/wire/modules/Process/ProcessPageList/ProcessPageList.module
@@ -142,7 +142,7 @@ class ProcessPageList extends Process implements ConfigurableModule {
 			if($this->openPage->id > 1) {
 				$openPageIDs[] = $this->openPage->id; 
 				foreach($this->openPage->parents() as $parent) {
-					if($parent->id > 1) $openPageIDs[] = $parent->id; 
+					if($parent->id > 1 && $parent->id != $this->id) $openPageIDs[] = $parent->id;
 				}
 			}
 


### PR DESCRIPTION
Prevents multiple renderings of one sub page in the page tree if the root node is not the "Home" page.