### PR TITLE
hasRole for comparison against multiple roles

### DIFF
--- a/wire/core/User.php
+++ b/wire/core/User.php
@@ -43,16 +43,33 @@ class User extends Page {
 	 *
 	 */
 	public function hasRole($role) {
-		
-		$roles = $this->get('roles');
-		$has = false; 
-		
-		if(empty($roles)) {
-			// do nothing
-			
-		} else if(is_object($role) && $role instanceof Page) {
-			$has = $roles->has($role); 
-			
+
+        	$roles = $this->get('roles');
+        	$has = false;
+
+	        if(empty($roles)) {
+	            // do nothing
+	
+	        } else if(is_object($role) && $role instanceof Page) {
+	            $has = $roles->has($role);
+	
+	        } else if(is_object($role) && $role instanceof PageArray) {
+	            foreach ($role as $page) {
+	                if ($this->hasRole($page)) {
+	                    $has = true;
+	                    break;
+	                }
+	            }
+	
+	        } else if(strpos($role, '|') !== false) {
+	            $multiroles = explode('|', $role);
+	            foreach ($multiroles as $singlerole) {
+	                if ($this->hasRole($singlerole)) {
+	                    $has = true;
+	                    break;
+	                }
+	            }
+
 		} else if(ctype_digit("$role")) {
 			$role = (int) $role; 
 			foreach($roles as $r) {
@@ -63,7 +80,7 @@ class User extends Page {
 			}
 			
 		} else if(is_string($role)) {
-			foreach($roles as $r) {
+            		foreach($roles as $r) {
 				if($r->name === $role) {
 					$has = true;
 					break;


### PR DESCRIPTION
I always get caught out by hasRole not being able to support multiple roles, so this should add support for a PageArray or a pipe-delimited string of role names or IDs.

Not thoroughly tested, but should work.