### PR TITLE
some enhancements and a fix to ImageSizer

### DIFF
--- a/wire/core/ImageSizer.php
+++ b/wire/core/ImageSizer.php
@@ -393,15 +393,12 @@ class ImageSizer extends Wire {
 		if($gdWidth == $targetWidth && $gdWidth == $this->image['width'] &&  $gdHeight == $this->image['height'] && $gdHeight == $targetHeight) {
 			
 			// this is the case if the original size is requested or a greater size but upscaling is set to false
+			
+			// the current version is allready the desired result, we only may have to apply compression where possible
+			$this->sharpening = 'none'; // we set sharpening to none
 
-			// since we have added support for crop-before-resize, we have to check for this
-			if(!is_array($this->cropExtra)) {
-				// the sourceimage is allready the targetimage, we can leave here
-				@imagedestroy($image);
-				return true;
-			}
-			// we have a cropped_before_resized image and need to save this version,
-			// so we let pass it through without further manipulation, we just need to copy it into the final memimage called "$thumb"
+			// and copy the current image into the final memimage called "$thumb",
+			// then we let pass it through without further manipulation
 			if(self::checkMemoryForImage(array(imagesx($image), imagesy($image), 3)) === false) {
 				throw new WireException(basename($source) . " - not enough memory to copy the final cropExtra");
 			}

--- a/wire/core/ImageSizer.php
+++ b/wire/core/ImageSizer.php
@@ -1845,6 +1845,38 @@ class ImageSizer extends Wire {
 		return ($phpMaxMem - $curMem >= $imgMem + (3 * 1048576)) ? true : false;
 	}
 
-
+	/**
+	 * Check orientation (@horst)
+	 *
+	 * @param mixed $image, pageimage or filename
+	 * @param mixed $correctionArray, null or array by reference
+	 * @return bool
+	 *
+	 */
+	static public function imageIsRotated($image, &$correctionArray = null) {
+		if($image instanceof Pageimage) {
+			$fn = $image->filename;
+		} elseif(is_readable($image)) {
+			$fn = $image;
+		} else {
+			return null;
+		}
+		// first value is rotation-degree and second value is flip-mode: 0=NONE | 1=HORIZONTAL | 2=VERTICAL
+		$corrections = array(
+			'1' => array(  0, 0),
+			'2' => array(  0, 1),
+			'3' => array(180, 0),
+			'4' => array(  0, 2),
+			'5' => array(270, 1),
+			'6' => array(270, 0),
+			'7' => array( 90, 1),
+			'8' => array( 90, 0)
+			);
+		if(!function_exists('exif_read_data')) return null;
+		$exif = @exif_read_data($fn, 'IFD0');
+		if(!is_array($exif) || !isset($exif['Orientation']) || !in_array(strval($exif['Orientation']), array_keys($corrections))) return null;
+		$correctionArray = $corrections[strval($exif['Orientation'])];
+		return $correctionArray[0] > 0;
+	}
 
 }


### PR DESCRIPTION
1) add static public method to check orientation
    this can be used with pageimages or with image filenames


2) add a static public function check for animated GIFs 
    can be used with pageimages or image filenames


3) added static public method to clean IPTC data 
   therefore it was needed to move IPTC write functionality from ___resize into an own method. IPTC writing to variations now do exclude custom tags that may be used internally.


4) bug fix with unresized variations 
   in cases where we have a JPEG variation and upscaling is not allowed, we need to save the variation so that the desired compression level will be applied!

