### PR TITLE
remove check for statusSystemID in module ProcessPageClone

### DIFF
--- a/wire/modules/Process/ProcessPageClone.module
+++ b/wire/modules/Process/ProcessPageClone.module
@@ -113,7 +113,7 @@ class ProcessPageClone extends Process {
 	public function hasPermission(Page $page) {
 		$user = $this->user; 
 
-		if($page->is(Page::statusSystem) || $page->is(Page::statusSystemID)) return false; 
+		if($page->is(Page::statusSystem)) return false; 
 		if($page->parent->template->noChildren) return false; 
 		if($page->template->noParents) return false; 
 


### PR DESCRIPTION
Removed check for statusSystemID, clone doesn't affect the id or delete the page, so clone doenst need to fail on that status.