### PR TITLE
remove check for statusSystemID and statusSystem in module ProcessPageClone

### DIFF
--- a/wire/core/Pages.php
+++ b/wire/core/Pages.php
@@ -1591,6 +1591,10 @@ class Pages extends Wire {
 		foreach($page->template->fieldgroup as $field) {
 			$page->get($field->name); 
 		}
+		
+		$oldStatus = $page->status;
+		$page->status = $page->status | Page::statusSystemOverride;
+		$page->status = 1;
 
 		// clone in memory
 		$copy = clone $page; 
@@ -1618,6 +1622,8 @@ class Pages extends Wire {
 			$this->cloning = true; 
 			$options['ignoreFamily'] = true; // skip family checks during clone
 			$this->save($copy, $options);
+			$copy->status = $oldStatus;
+			$copy->save();
 		} catch(Exception $e) {
 			$this->cloning = false;
 			throw $e;

--- a/wire/modules/Process/ProcessPageClone.module
+++ b/wire/modules/Process/ProcessPageClone.module
@@ -113,7 +113,6 @@ class ProcessPageClone extends Process {
 	public function hasPermission(Page $page) {
 		$user = $this->user; 
 
-		if($page->is(Page::statusSystem)) return false; 
 		if($page->parent->template->noChildren) return false; 
 		if($page->template->noParents) return false; 
 

--- a/wire/modules/Process/ProcessPageClone.module
+++ b/wire/modules/Process/ProcessPageClone.module
@@ -113,7 +113,7 @@ class ProcessPageClone extends Process {
 	public function hasPermission(Page $page) {
 		$user = $this->user; 
 
-		if($page->is(Page::statusSystem) || $page->is(Page::statusSystemID)) return false; 
+		if($page->is(Page::statusSystem)) return false; 
 		if($page->parent->template->noChildren) return false; 
 		if($page->template->noParents) return false; 
 


### PR DESCRIPTION
With the proposed change to Pages::___clone(), having statusSystemID or statusSystem on a page should no longer block the cloning of a page/tree, so its check can be removed from ProcessPageClone.