### PR TITLE
Page cache: Handle AJAX requests separately

### DIFF
--- a/wire/modules/PageRender.module
+++ b/wire/modules/PageRender.module
@@ -171,6 +171,10 @@ class PageRender extends WireData implements Module, ConfigurableModule {
 				$secondaryID .= md5($options['prependFile'] . '+' . $options['appendFile'] . '+' . $options['filename']) . '+';
 			}
 
+            if ($this->config->ajax) {
+                $secondaryID .= 'ajax+';
+            }
+
 			if($pageNum > 1) $secondaryID .= "page{$pageNum}";
 			$secondaryID = rtrim($secondaryID, '+'); 
 			if(wire('languages')) { 


### PR DESCRIPTION
If a ressource for which template-level page caching is active is requested via AJAX, the response should be cached separately from the non-AJAX response.