### PR TITLE
Help with UX for transparent / white images in admin

### DIFF
--- a/wire/modules/Inputfield/InputfieldImage/InputfieldImage.css
+++ b/wire/modules/Inputfield/InputfieldImage/InputfieldImage.css
@@ -1,8 +1,10 @@
 .InputfieldImage img {
 	max-width: 90%; 
+	background-color: rgba(0,0,0,0.25);
 }
 .InputfieldImage img:hover {
 	cursor: zoom-in;
+	background-color: rgba(0,0,0,0.1);
 }
 
 .InputfieldImage a.InputfieldFileLink + label.InputfieldFileDescription,

--- a/wire/modules/Process/ProcessPageEditImageSelect/ProcessPageEditImageSelect.css
+++ b/wire/modules/Process/ProcessPageEditImageSelect/ProcessPageEditImageSelect.css
@@ -13,6 +13,7 @@
 	float: left;
 	margin: 0 0.5em 0.5em 0;
 	border: none;
+	background-color: rgba(0,0,0,0.25);
 }
 	#select_images.thumbs a:hover img {
 		border: none;


### PR DESCRIPTION
The UX when uploading transparent / white images is awkward. By adding a background colour to the img tags it allows the user to be able to select the images far easier when otherwise they would be invisible.
Furthermore by applying the background colour to the img tags it doesn't encroach on the design of the admin for images which are not transparent.