### PR TITLE
Match column heights when inputfield heights change

### DIFF
--- a/wire/modules/Inputfield/InputfieldFile/InputfieldFile.js
+++ b/wire/modules/Inputfield/InputfieldFile/InputfieldFile.js
@@ -23,11 +23,11 @@ $(document).ready(function() {
 		if($t.is(":checked")) {
 			// not an error, but we want to highlight it in the same manner
 			$t.parents(".InputfieldFileInfo").addClass("ui-state-error")
-				.siblings(".InputfieldFileData").slideUp("fast");
+				.siblings(".InputfieldFileData").slideUp("fast", InputfieldColumnWidths);
 
 		} else {
 			$t.parents(".InputfieldFileInfo").removeClass("ui-state-error")
-				.siblings(".InputfieldFileData").slideDown("fast");
+				.siblings(".InputfieldFileData").slideDown("fast", InputfieldColumnWidths);
 		}	
 	}
 

--- a/wire/modules/Inputfield/InputfieldImage/InputfieldImage.js
+++ b/wire/modules/Inputfield/InputfieldImage/InputfieldImage.js
@@ -98,6 +98,7 @@ $(document).ready(function() {
 			unsetGridMode($parent);
 			setGridMode($parent);
 		}
+		InputfieldColumnWidths();
 	}); 
 
 });


### PR DESCRIPTION
Columns get out of alignment when the height of the inputfields within
the columns change. Any action that affects column height should fire
the InputfieldColumnWidths() function.

CKEditor fields also need:
CKEDITOR.on("instanceReady", function(){
InputfieldColumnWidths();
});
...because the inputfield height can change after CKEditor loads, but
I'm not sure of the best place to add this.