### PR TITLE
Make json nav sort in a case insensitive manner

### DIFF
--- a/wire/core/Process.php
+++ b/wire/core/Process.php
@@ -358,7 +358,7 @@ abstract class Process extends WireData implements Module {
 				'icon' => $icon, 
 			);
 		}
-		if($options['sort']) ksort($data['list']); // sort alpha
+		if($options['sort']) uksort($data['list'], 'strcasecmp'); // sort alpha, case insensitive
 		$data['list'] = array_values($data['list']); 
 
 		if($this->wire('config')->ajax) header("Content-Type: application/json");


### PR DESCRIPTION
I changed the way sorting works for json nav items. It's still an alphanumerical sort but is case insensitive. I believe this is more user friendly. Backwards compatible to PHP4.

Fixes ryancramerdesign/ProcessWire#1310