### PR TITLE
added memory control for sharpening and more

### DIFF
--- a/wire/config.php
+++ b/wire/config.php
@@ -469,7 +469,8 @@ $config->imageSizerOptions = array(
 	'sharpening' => 'soft', // sharpening: none | soft | medium | strong
 	'quality' => 90, // quality: 1-100 where higher is better but bigger
 	'hidpiQuality' => 60, // Same as above quality setting, but specific to hidpi images
-	'defaultGamma' => 2.0, // defaultGamma: 0.5 to 4.0 or -1 to disable gamma correction (default=2.0)
+	'defaultGamma' => 2.2, // defaultGamma: 0.5 to 4.0 or -1 to disable gamma correction (default=2.2)
+	'useUSM' => true, // sharpening with the UnsharpMaskAlgorithm, is toggled off on systems with low memory
 	);
 
 /**

--- a/wire/core/ImageSizer.php
+++ b/wire/core/ImageSizer.php
@@ -186,6 +186,7 @@ class ImageSizer extends Wire {
 		'scale', 
 		'rotate',
 		'flip', 
+		'useUSM', 
 		);
 
 	/**
@@ -242,10 +243,6 @@ class ImageSizer extends Wire {
 	
 		// ensures the resize doesn't timeout the request (with at least 30 seconds)
 		$this->setTimeLimit(); 
-
-		// set the use of UnSharpMask as default, can be overwritten per pageimage options
-		// or per $config->imageSizerOptions in site/config.php
-		$this->options['useUSM'] = true;
 
 		// filling all options with global custom values from config.php
 		$options = array_merge($this->wire('config')->imageSizerOptions, $options); 
@@ -418,7 +415,7 @@ class ImageSizer extends Wire {
 			
 			
 			if(self::checkMemoryForImage(array(imagesx($image), imagesy($image), 3)) === false) {
-				throw new WireException(basename($source) . " - not enough memory to copy the final cropExtra");
+				throw new WireException(basename($source) . " - not enough memory to copy the final image");
 			}
 			$thumb = imagecreatetruecolor(imagesx($image), imagesy($image));          // create the final memory image
 			$this->prepareImageLayer($thumb, $image);
@@ -431,7 +428,6 @@ class ImageSizer extends Wire {
 			if(self::checkMemoryForImage(array($gdWidth, $gdHeight, 3)) === false) {
 				throw new WireException(basename($source) . " - not enough memory to resize to the final image");
 			}
-
 			$thumb = imagecreatetruecolor($gdWidth, $gdHeight);
 			$this->prepareImageLayer($thumb, $image);
 			imagecopyresampled($thumb, $image, 0, 0, 0, 0, $gdWidth, $gdHeight, $this->image['width'], $this->image['height']);
@@ -443,7 +439,6 @@ class ImageSizer extends Wire {
 			if(self::checkMemoryForImage(array($gdWidth, $gdHeight, 3)) === false) {
 				throw new WireException(basename($source) . " - not enough memory to resize to the intermediate image");
 			}
-
 			$thumb2 = imagecreatetruecolor($gdWidth, $gdHeight);
 			$this->prepareImageLayer($thumb2, $image);
 			imagecopyresampled($thumb2, $image, 0, 0, 0, 0, $gdWidth, $gdHeight, $this->image['width'], $this->image['height']);
@@ -451,19 +446,31 @@ class ImageSizer extends Wire {
 			if(self::checkMemoryForImage(array($targetWidth, $targetHeight, 3)) === false) {
 				throw new WireException(basename($source) . " - not enough memory to crop to the final image");
 			}
-
 			$thumb = imagecreatetruecolor($targetWidth, $targetHeight);
 			$this->prepareImageLayer($thumb, $image);
 			imagecopyresampled($thumb, $thumb2, 0, 0, $x1, $y1, $targetWidth, $targetHeight, $targetWidth, $targetHeight);
 			imagedestroy($thumb2);
 		}
 
+		if(isset($image) && is_resource($image)) @imagedestroy($image); // @horst
+		if(isset($thumb2) && is_resource($thumb2)) @imagedestroy($thumb2);
+		if(isset($image)) $image = null;
+		if(isset($thumb2)) $thumb2 = null;
+
 		// optionally apply sharpening to the final thumb
 		if($this->sharpening && $this->sharpening != 'none') { // @horst
 			if(IMAGETYPE_PNG != $this->imageType || ! $this->hasAlphaChannel()) {
-				// is needed for the USM sharpening function to calculate the best sharpening params
-				$this->usmValue = $this->calculateUSMfactor($targetWidth, $targetHeight);
-				$thumb = $this->imSharpen($thumb, $this->sharpening);
+				// calculate if there is enough memory available to apply the USM algorithm, if enabled
+				$this->useUSM = self::checkMemoryForImage(array(imagesx($thumb), imagesy($thumb), 3), array(imagesx($thumb), imagesy($thumb), 3)) === false ? false : $this->useUSM;
+				if($this->useUSM) {
+					// is needed for the USM sharpening function to calculate the best sharpening params
+					$this->usmValue = $this->calculateUSMfactor($targetWidth, $targetHeight);
+					$thumb = $this->imSharpen($thumb, $this->sharpening);
+				} else {
+					if(self::checkMemoryForImage(array(imagesx($thumb), imagesy($thumb), 3)) !== false) {
+						$thumb = $this->imSharpen($thumb, $this->sharpening);
+					}
+				}
 			}
 		}
 
@@ -487,13 +494,8 @@ class ImageSizer extends Wire {
 				break;
 		}
 
-		if(isset($image) && is_resource($image)) @imagedestroy($image); // @horst
 		if(isset($thumb) && is_resource($thumb)) @imagedestroy($thumb);
-		if(isset($thumb2) && is_resource($thumb2)) @imagedestroy($thumb2);
-		
-		if(isset($image)) $image = null;
 		if(isset($thumb)) $thumb = null;
-		if(isset($thumb2)) $thumb2 = null;
 
 		if($result === false) {
 			if(is_file($dest)) @unlink($dest); 
@@ -1010,6 +1012,18 @@ class ImageSizer extends Wire {
 	}
 	
 	/**
+	 * Toggle on/off the usage of USM algorithm for sharpening
+	 * 
+	 * @param bool $value Whether to USM is used or not (default = true)
+	 * @return $this
+	 * 
+	 */
+	public function setUseUSM($value = true) {
+		$this->useUSM = true === $this->getBooleanValue($value) ? true : false;
+		return $this; 
+	}
+	
+	/**
 	 * Set flip
 	 *
 	 * Specify one of: 'vertical' or 'horizontal', also accepts
@@ -1057,6 +1071,7 @@ class ImageSizer extends Wire {
 				case 'hidpi': $this->setHidpi($value); break;
 				case 'rotate': $this->setRotate($value); break;
 				case 'flip': $this->setFlip($value); break;
+				case 'useUSM': $this->setUseUsm($value); break;
 							  
 				default: 
 					// unknown or 3rd party option
@@ -1226,6 +1241,10 @@ class ImageSizer extends Wire {
 	protected function imFlip($im, $vertical = false) {
 		$sx  = imagesx($im);
 		$sy  = imagesy($im);
+		if(self::checkMemoryForImage(array($sx, $sy, 3)) === false) {
+			#throw new WireException("Not enough memory to process flip conversion for: " . basename($this->filename));
+			return $im2;
+		}
 		$im2 = @imagecreatetruecolor($sx, $sy);
 		if($vertical === true) {
 			@imagecopyresampled($im2, $im, 0, 0, 0, ($sy-1), $sx, $sy, $sx, 0-$sy);
@@ -1245,16 +1264,15 @@ class ImageSizer extends Wire {
 	 */
 	protected function imSharpen($im, $mode) {
 
-		// check if we have to use an individual value for "useUSM"
-		if(isset($this->options['useUSM'])) {
-			$this->useUSM = $this->getBooleanValue($this->options['useUSM']);
-		}
-
 		// due to a bug in PHP's bundled GD-Lib with the function imageconvolution in some PHP versions
 		// we have to bypass this for those who have to run on this PHP versions
 		// see: https://bugs.php.net/bug.php?id=66714
 		// and here under GD: http://php.net/ChangeLog-5.php#5.5.11
 		$buggyPHP = (version_compare(phpversion(), '5.5.8', '>') && version_compare(phpversion(), '5.5.11', '<')) ? true : false;
+		if($buggyPHP && !$this->useUSM && self::checkMemoryForImage(array(imagesx($im), imagesy($im), 3), array(imagesx($im), imagesy($im), 3)) !== true) {
+			// we have not enough memory available for USM and cannot use the other algorithm because of the buggy PHP version
+			return $im;
+		}
 
 		// USM method is used for buggy PHP versions
 		// for regular versions it can be omitted per: useUSM = false passes as pageimage option
@@ -1622,7 +1640,6 @@ class ImageSizer extends Wire {
 	 *
 	 */
 	protected function unsharpMask($img, $amount, $radius, $threshold) {
-
 
 		// Attempt to calibrate the parameters to Photoshop:
 		if($amount > 500) $amount = 500;

--- a/wire/core/ImageSizer.php
+++ b/wire/core/ImageSizer.php
@@ -150,12 +150,6 @@ class ImageSizer extends Wire {
 	protected $defaultGamma = 2.0;
 
 	/**
-	 * Factor to use when determining if enough memory available for resize. 
-	 *
-	 */
-	protected $memoryCheckFactor = 2.2; 
-
-	/**
 	 * Other options for 3rd party use
 	 *
 	 */
@@ -460,14 +454,18 @@ class ImageSizer extends Wire {
 		// optionally apply sharpening to the final thumb
 		if($this->sharpening && $this->sharpening != 'none') { // @horst
 			if(IMAGETYPE_PNG != $this->imageType || ! $this->hasAlphaChannel()) {
-				// calculate if there is enough memory available to apply the USM algorithm, if enabled
-				$this->useUSM = self::checkMemoryForImage(array(imagesx($thumb), imagesy($thumb), 3), array(imagesx($thumb), imagesy($thumb), 3)) === false ? false : $this->useUSM;
+				$w = imagesx($thumb);
+				$h = imagesy($thumb);
 				if($this->useUSM) {
-					// is needed for the USM sharpening function to calculate the best sharpening params
-					$this->usmValue = $this->calculateUSMfactor($targetWidth, $targetHeight);
-					$thumb = $this->imSharpen($thumb, $this->sharpening);
-				} else {
-					if(self::checkMemoryForImage(array(imagesx($thumb), imagesy($thumb), 3)) !== false) {
+					// calculate if there is enough memory available to apply the USM algorithm, if enabled
+					if(true === ($this->useUSM = self::checkMemoryForImage(array($w, $h, 3), array($w, $h, 3)))) {
+						// is needed for the USM sharpening function to calculate the best sharpening params
+						$this->usmValue = $this->calculateUSMfactor($targetWidth, $targetHeight);
+						$thumb = $this->imSharpen($thumb, $this->sharpening);
+					}
+				}
+				if(!$this->useUSM) {
+					if(false !== self::checkMemoryForImage(array($w, $h, 3))) {
 						$thumb = $this->imSharpen($thumb, $this->sharpening);
 					}
 				}

--- a/wire/core/ImageSizer.php
+++ b/wire/core/ImageSizer.php
@@ -133,6 +133,14 @@ class ImageSizer extends Wire {
 	protected $flip = '';
 
 	/**
+	 * Indicates which sharpening algorythm should be used
+	 * 
+	 * @var bool
+	 * 
+	 */
+	protected $useUSM = true; 
+
+	/**
 	 * default gamma correction: 0.5 - 4.0 | -1 to disable gammacorrection, default = 2.0
 	 * 
 	 * can be overridden by setting it to $config->imageSizerOptions['defaultGamma']

--- a/wire/core/Pageimage.php
+++ b/wire/core/Pageimage.php
@@ -298,7 +298,8 @@ class Pageimage extends Pagefile {
 			'hidpi' => false, 
 			'cleanFilename' => false, // clean filename of historial resize information
 			'rotate' => 0,
-			'flip' => '', 
+			'flip' => '',
+			'useUSM' => true,
 			);
 
 		$this->error = '';


### PR DESCRIPTION
added useUSM to default settings in Pageimage.php
added useUSM to $config->imageSizerOptions in config.php
added useUSM to ImageSizer.php
added memory checking for all parts related to sharpening
rearranged freeing of memory with imagedestroy

changed value for defaultGamma from 2.0 to 2.2 in config.php
fixed a typo in Imagesizer.php

--------

@ryancramerdesign: Please refer to this forum thread to get more informations: https://processwire.com/talk/topic/12015-memory-limit-error-with-images/#entry111840

In short, there were uncontrolled memory allocations in the unsharpMask function that has potential to crash pages. This is fixed now. Also I added the ability on user level to specify selection of the used sharpening algorithm.
