### PR TITLE
Added support for multiple response headers of the same type

### DIFF
--- a/wire/core/WireHttp.php
+++ b/wire/core/WireHttp.php
@@ -812,7 +812,15 @@ class WireHttp extends Wire {
 				$key = $header;
 				$value = '';
 			}
-			if(!isset($this->responseHeaders[$key])) $this->responseHeaders[$key] = $value;
+			if(!isset($this->responseHeaders[$key])) {
+				$this->responseHeaders[$key] = $value;
+			}
+			else if(is_array($this->responseHeaders[$key])) {
+				$this->responseHeaders[$key][] = $value;
+			}
+			else {
+				$this->responseHeaders[$key] = array($this->responseHeaders[$key], $value);
+			}
 		}
 	
 		/*


### PR DESCRIPTION
HTTP responses can have multiples of one type of header, e.g. Link: headers. This update will handle parsing multiple headers of the same type into a nested array instead of using the first one returned. If only one header is returned for a type, it remains a basic key => string mapping.

Sample response for http://werd.io with this update:

```
Array
(
    [HTTP/1.0 200 OK] => 
    [date] => Sat, 20 Feb 2016 08:36:54 GMT
    [server] => Apache
    [p3p] => CP="CAO PSA OUR"
    [set-cookie] => werdmuller=vqtvt776ik565g597nhk2fslfq10alvulv4jqnn3cavd8pui66g1; expires=Sat, 27-Feb-2016 08:36:54 GMT; Max-Age=604800; path=/; HttpOnly
    [expires] => Thu, 19 Nov 1981 08:52:00 GMT
    [cache-control] => no-store, no-cache, must-revalidate, post-check=0, pre-check=0
    [pragma] => no-cache
    [link] => Array
        (
            [0] => <http://werd.io/micropub/endpoint>; rel="micropub"
            [1] => <http://werd.io/webmention/>; rel="http://webmention.org/"
            [2] => <http://werd.io/webmention/>; rel="webmention"
            [3] => <http://benwerd.superfeedr.com/>; rel="hub"
            [4] => <http://werd.io/>; rel="self"
        )

    [x-powered-by] => https://withknown.com
    [x-clacks-overhead] => GNU Terry Pratchett
    [last-modified] => Mon, 15 Feb 2016 21:43:33 GMT
    [access-control-allow-origin] => *
    [vary] => Accept-Encoding
    [content-type] => text/html;charset=utf-8
    [connection] => close
)
```

Sample response for http://gregorlove.com with this update:

```
Array
(
    [HTTP/1.1 200 OK] => 
    [date] => Sat, 20 Feb 2016 08:44:17 GMT
    [server] => Apache
    [expires] => Thu, 19 Nov 1981 08:52:00 GMT
    [cache-control] => no-store, no-cache, must-revalidate, post-check=0, pre-check=0
    [pragma] => no-cache
    [link] => <http://gregorlove.com/webmention/>; rel="webmention"
    [set-cookie] => wire=c2ntUpAwcIy5LL%2Crjx4iJ1; path=/; HttpOnly
    [x-frame-options] => SAMEORIGIN
    [x-xss-protection] => 1; mode=block
    [vary] => Accept-Encoding
    [connection] => close
    [content-type] => text/html; charset=utf-8
)
```
