### PR TITLE
Update .htaccess.txt to support Let´s encrypt

### DIFF
--- a/htaccess.txt
+++ b/htaccess.txt
@@ -127,9 +127,9 @@ DirectoryIndex index.php index.html index.htm
 
   # -----------------------------------------------------------------------------------------------
   # Access Restrictions: Keep web users out of dirs that begin with a period
+  # but let services like Let´s encrypt use the webroot authentication method 
   # -----------------------------------------------------------------------------------------------
-
-  RewriteRule "(^|/)\." - [F]
+  RewriteRule "(^|/)\.(?!well-known)" - [F]
 
   # -----------------------------------------------------------------------------------------------
   # OPTIONAL: Redirect users to the 'www.' version of the site (uncomment to enable).


### PR DESCRIPTION
Allow services like Let´s encrypt to use the webroot authentication method

You can see the same fix in Drupals .htaccess file.
Also see https://community.letsencrypt.org/t/drupals-defualt-htaccess-file-breaks-webroot-authentication/3014 
