### PR TITLE
Improve accessibility in site profiles

### DIFF
--- a/site-beginner/templates/_foot.php
+++ b/site-beginner/templates/_foot.php
@@ -1,6 +1,6 @@
 
 
-	</div><!--/#main-->
+	</main><!--/#main-->
 
 	<!-- footer -->
 	<footer id='footer'>

--- a/site-beginner/templates/_head.php
+++ b/site-beginner/templates/_head.php
@@ -10,8 +10,10 @@
 </head>
 <body class='has-sidebar'>
 
+	<a href="#main" class="visually-hidden element-focusable bypass-to-main">Skip to content</a>
+
 	<!-- top navigation -->
-	<ul class='topnav'><?php 
+	<ul class='topnav' role='navigation'><?php
 
 		// top navigation consists of homepage and its visible children
 		$homepage = $pages->get('/'); 
@@ -40,12 +42,13 @@
 
 	<!-- search form -->
 	<form class='search' action='<?php echo $pages->get('template=search')->url; ?>' method='get'>
-		<input type='text' name='q' placeholder='Search' value='' />
-		<button type='submit' name='submit'>Search</button>
+		<label for='search' class='visually-hidden'>Search:</label>
+		<input id='search' type='text' name='q' placeholder='Search' value='' />
+		<button type='submit' name='submit' class='visually-hidden'>Search</button>
 	</form>
 
 	<!-- breadcrumbs -->
-	<div class='breadcrumbs'><?php 
+	<div class='breadcrumbs' role='navigation' aria-label='You are here:'><?php
 
 		// breadcrumbs are the current page's parents
 		foreach($page->parents() as $item) {
@@ -56,5 +59,5 @@
 
 	?></div>
 
-	<div id='main'>
+	<main id='main'>
 

--- a/site-beginner/templates/basic-page.php
+++ b/site-beginner/templates/basic-page.php
@@ -23,7 +23,7 @@ include('./_head.php'); // include header markup ?>
 	
 	?></div><!-- end content -->
 
-	<div id='sidebar'><?php
+	<aside id='sidebar'><?php
 	
 		// rootParent is the parent page closest to the homepage
 		// you can think of this as the "section" that the user is in
@@ -40,6 +40,6 @@ include('./_head.php'); // include header markup ?>
 		// output sidebar text if the page has it
 		echo $page->sidebar; 
 	
-	?></div><!-- end sidebar -->
+	?></aside><!-- end sidebar -->
 
 <?php include('./_foot.php'); // include footer markup ?>

--- a/site-beginner/templates/styles/main.css
+++ b/site-beginner/templates/styles/main.css
@@ -6,6 +6,7 @@
  * 3. Main content and sidebar
  * 4. Footer
  * 5. Media queries for responsive layout
+ * 6. Accessibility
  * 
  */
 
@@ -123,9 +124,6 @@ form.search {
 		padding: 0.25em 0.5em;
 		border: 1px solid #ccc; 
 		width: 100%; 
-	}
-	form.search button {
-		display: none; 
 	}
 
 .breadcrumbs {
@@ -290,4 +288,43 @@ figure figcaption {
 	body, td, textarea {
 		font-size: 115%; 
 	}
+}
+
+/*********************************************************************
+ * 6. Accessibility
+ *
+ */
+
+/* Hide visually, but remain approachable for screenreader */
+
+.visually-hidden {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(1px, 1px, 1px, 1px);
+	border: 0;
+}
+
+/* Show bypass link on hover */
+
+.element-focusable:focus {
+	clip: auto;
+	overflow: visible;
+	height: auto;
+}
+
+/* Sample styling for bypass link */
+
+.bypass-to-main:focus {
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 40px;
+	line-height: 40px;
+	text-align: center;
+	background: #333;
+	color: #fff;
 }

--- a/site-classic/templates/foot.inc
+++ b/site-classic/templates/foot.inc
@@ -24,7 +24,7 @@ if($page->numChildren) {
 
 	</div><!--/content-->
 
-	<div id="footer" class="footer">
+	<div id="footer" class="footer" role="contentinfo">
 		<div class="container">
 			<p>Powered by <a href='http://processwire.com'>ProcessWire Open Source CMS/CMF</a></p>
 		</div>

--- a/site-classic/templates/head.inc
+++ b/site-classic/templates/head.inc
@@ -32,6 +32,8 @@
 </head>
 <body>
 
+	<a href="#bodycopy" class="visually-hidden element-focusable bypass-to-main">Skip to content</a>
+
 	<p id='bgtitle'><?php 
 
 		// print the section title as big faded text that appears near the top left of the page
@@ -45,7 +47,7 @@
 
 			<a href='<?php echo $config->urls->root; ?>'><p id='logo'>ProcessWire</p></a>
 		
-			<ul id='topnav'><?php
+			<ul id='topnav' role='navigation'><?php
 			
 				// Create the top navigation list by listing the children of the homepage. 
 				// If the section we are in is the current (identified by $page->rootParent)
@@ -64,7 +66,7 @@
 
 			?></ul>
 
-			<ul id='breadcrumb'><?php
+			<ul id='breadcrumb' role='navigation' aria-label='You are here:'><?php
 
 				// Create breadcrumb navigation by cycling through the current $page's
 				// parents in order, linking to each:
@@ -87,6 +89,7 @@
 			?></h1>
 
 			<form id='search_form' action='<?php echo $config->urls->root?>search/' method='get'>
+				<label for='search_query' class='visually-hidden'>Search</label>
 				<input type='text' name='q' id='search_query' value='<?php echo htmlentities($input->whitelist('q'), ENT_QUOTES, 'UTF-8'); ?>' />
 				<button type='submit' id='search_submit'>Search</button>
 			</form>
@@ -111,7 +114,7 @@
 
 		<div class="container">
 
-			<div id="sidebar">
+			<div id="sidebar" role='complementary'>
 
 				<?php
 
@@ -128,7 +131,7 @@
 					// We have determined that we're not on the homepage
 					// and that this section has child pages, so make navigation: 
 
-					echo "<ul id='subnav' class='nav'>";
+					echo "<ul id='subnav' class='nav' role='navigation'>";
 
 					foreach($page->rootParent->children as $child) {
 						$class = $page === $child ? " class='on'" : '';
@@ -156,5 +159,5 @@
 
 			</div><!--/sidebar-->
 
-			<div id="bodycopy">
+			<div id="bodycopy" role="main">
 			

--- a/site-classic/templates/styles/main.css
+++ b/site-classic/templates/styles/main.css
@@ -502,3 +502,43 @@ body, input, textarea, table {
 	z-index: 9999;
 }
 
+/**
+ * Accessibility helpers
+ *
+ */
+
+/* Hide visually, but remain approachable for screenreader */
+
+.visually-hidden {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(1px, 1px, 1px, 1px);
+	border: 0;
+}
+
+/* Show bypass link on hover */
+
+.element-focusable:focus {
+	clip: auto;
+	overflow: visible;
+	height: auto;
+}
+
+/* Sample styling for bypass link */
+
+.bypass-to-main:focus {
+	top: 0;
+	left: 0;
+	z-index: 20;
+	width: 100%;
+	height: 40px;
+	line-height: 40px;
+	text-align: center;
+	background: #DD0074;
+	color: #fff;
+}
+

--- a/site-default/templates/_main.php
+++ b/site-default/templates/_main.php
@@ -41,8 +41,10 @@
 </head>
 <body class="<?php if($sidebar) echo "has-sidebar "; ?>">
 
+	<a href="#main" class="visually-hidden element-focusable bypass-to-main">Skip to content</a>
+
 	<!-- top navigation -->
-	<ul class='topnav'><?php 
+	<ul class='topnav' role='navigation'><?php
 		// top navigation consists of homepage and its visible children
 		foreach($homepage->and($homepage->children) as $item) {
 			if($item->id == $page->rootParent->id) {
@@ -59,12 +61,13 @@
 
 	<!-- search form-->
 	<form class='search' action='<?php echo $pages->get('template=search')->url; ?>' method='get'>
-		<input type='text' name='q' placeholder='Search' value='<?php echo $sanitizer->entities($input->whitelist('q')); ?>' />
-		<button type='submit' name='submit'>Search</button>
+		<label for='search' class='visually-hidden'>Search:</label>
+		<input id='search' type='text' name='q' placeholder='Search' value='<?php echo $sanitizer->entities($input->whitelist('q')); ?>' />
+		<button type='submit' name='submit' class='visually-hidden'>Search</button>
 	</form>
 
 	<!-- breadcrumbs -->
-	<div class='breadcrumbs'><?php 
+	<div class='breadcrumbs' role='navigation' aria-label='You are here:'><?php
 		// breadcrumbs are the current page's parents
 		foreach($page->parents() as $item) {
 			echo "<span><a href='$item->url'>$item->title</a></span> "; 
@@ -73,7 +76,7 @@
 		echo "<span>$page->title</span> "; 
 	?></div>
 
-	<div id='main'>
+	<main id='main'>
 
 		<!-- main content -->
 		<div id='content'>
@@ -83,12 +86,12 @@
 
 		<!-- sidebar content -->
 		<?php if($sidebar): ?>
-		<div id='sidebar'>
+		<aside id='sidebar'>
 			<?php echo $sidebar; ?>
-		</div>
+		</aside>
 		<?php endif; ?>
 
-	</div>
+	</main>
 
 	<!-- footer -->
 	<footer id='footer'>

--- a/site-default/templates/styles/main.css
+++ b/site-default/templates/styles/main.css
@@ -6,7 +6,8 @@
  * 3. Main content and sidebar
  * 4. Footer
  * 5. Media queries for responsive layout
- * 
+ * 6. Accessibility
+ *
  */
 
 /*********************************************************************
@@ -123,9 +124,6 @@ form.search {
 		padding: 0.25em 0.5em;
 		border: 1px solid #ccc; 
 		width: 100%; 
-	}
-	form.search button {
-		display: none; 
 	}
 
 .breadcrumbs {
@@ -296,4 +294,44 @@ figure figcaption {
 	body, td, textarea {
 		font-size: 115%; 
 	}
+}
+
+
+/*********************************************************************
+ * 6. Accessibility
+ *
+ */
+
+/* Hide visually, but remain approachable for screenreader */
+
+.visually-hidden {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(1px, 1px, 1px, 1px);
+	border: 0;
+}
+
+/* Show bypass link on hover */
+
+.element-focusable:focus {
+	clip: auto;
+	overflow: visible;
+	height: auto;
+}
+
+/* Sample styling for bypass link */
+
+.bypass-to-main:focus {
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 40px;
+	line-height: 40px;
+	text-align: center;
+	background: #333;
+	color: #fff;
 }

--- a/site-languages/templates/_main.php
+++ b/site-languages/templates/_main.php
@@ -60,8 +60,10 @@
 </head>
 <body class="<?php if($sidebar) echo "has-sidebar"; ?>">
 
+	<a href="#main" class="visually-hidden element-focusable bypass-to-main"><?php echo _x('Skip to content', 'bypass'); ?></a>
+
 	<!-- language switcher / navigation -->
-	<ul class='languages'><?php
+	<ul class='languages' role='navigation'><?php
 		foreach($languages as $language) {
 			if(!$page->viewable($language)) continue; // is page viewable in this language?
 			if($language->id == $user->language->id) {
@@ -76,7 +78,7 @@
 	?></ul>
 
 	<!-- top navigation -->
-	<ul class='topnav'><?php 
+	<ul class='topnav' role='navigation'><?php
 		// top navigation consists of homepage and its visible children
 		foreach($homepage->and($homepage->children) as $item) {
 			if($item->id == $page->rootParent->id) {
@@ -92,7 +94,7 @@
 	?></ul>
 
 	<!-- breadcrumbs -->
-	<div class='breadcrumbs'><?php 
+	<div class='breadcrumbs' role='navigation' aria-label='<?php echo _x('You are here:', 'breadcrumbs'); ?>'><?php
 		// breadcrumbs are the current page's parents
 		foreach($page->parents() as $item) {
 			echo "<span><a href='$item->url'>$item->title</a></span> "; 
@@ -103,12 +105,13 @@
 
 	<!-- search engine -->
 	<form class='search' action='<?php echo $pages->get('template=search')->url; ?>' method='get'>
-		<input type='text' name='q' placeholder='<?php echo _x('Search', 'placeholder'); ?>' />
-		<button type='submit' name='submit'><?php echo _x('Search', 'button'); ?></button>
+		<label for='search' class='visually-hidden'>Search:</label>
+		<input id='search' type='text' name='q' placeholder='<?php echo _x('Search', 'placeholder'); ?>' />
+		<button type='submit' name='submit' class='visually-hidden'><?php echo _x('Search', 'button'); ?></button>
 	</form>
 
 
-	<div id='main'>
+	<main id='main'>
 
 		<!-- main content -->
 		<div id='content'>
@@ -121,15 +124,15 @@
 		<!-- sidebar content -->
 		<?php if($sidebar): ?>
 			
-		<div id='sidebar'>
+		<aside id='sidebar'>
 			
 			<?php echo $sidebar; ?>
 			
-		</div>
+		</aside>
 			
 		<?php endif; ?>
 
-	</div>
+	</main>
 
 	<!-- footer -->
 	<footer id='footer'>

--- a/site-languages/templates/styles/main.css
+++ b/site-languages/templates/styles/main.css
@@ -6,7 +6,8 @@
  * 3. Main content and sidebar
  * 4. Footer
  * 5. Media queries for responsive layout
- * 
+ * 6. Accessibility
+ *
  */
 
 /*********************************************************************
@@ -155,9 +156,6 @@ form.search {
 		padding: 0.25em 0.5em;
 		border: 1px solid #ccc; 
 		width: 100%; 
-	}
-	form.search button {
-		display: none; 
 	}
 
 .breadcrumbs {
@@ -350,4 +348,44 @@ figure figcaption {
 	body, td, textarea {
 		font-size: 115%; 
 	}
+}
+
+
+/*********************************************************************
+ * 6. Accessibility
+ *
+ */
+
+/* Hide visually, but remain approachable for screenreader */
+
+.visually-hidden {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(1px, 1px, 1px, 1px);
+	border: 0;
+}
+
+/* Show bypass link on hover */
+
+.element-focusable:focus {
+	clip: auto;
+	overflow: visible;
+	height: auto;
+}
+
+/* Sample styling for bypass link */
+
+.bypass-to-main:focus {
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 40px;
+	line-height: 40px;
+	text-align: center;
+	background: #333;
+	color: #fff;
 }


### PR DESCRIPTION
While ProcessWire's site profiles aren't as central to PW as other core themes to other Content Management Systems ProcessWire should at least inspire developers to make their ProcessWire websites more accessible.

Both "core themes" of WordPress and Drupal (8), Twenty Sixteen and Bartik lead themers by good example, accessibility-wise. ProcessWire should do this as well, in my opinion.

The changes in this merge request do not affect the visual output of the core site profiles, but:

* their behaviour when using a site profile via keyboard, by adding a "jump to content" bypass block
* their output towards screen readers, especially regarding the search form (I added labels since placeholders [should never be used as form input labels](https://www.nngroup.com/articles/form-design-placeholders/) and changed the way of hiding elements)
* their semantics (main, aside, role-attributes)