### PR TITLE
Check for page-delete permission to thrash a page

### DIFF
--- a/wire/modules/Process/ProcessPageList/ProcessPageListActions.php
+++ b/wire/modules/Process/ProcessPageList/ProcessPageListActions.php
@@ -162,7 +162,7 @@ class ProcessPageListActions extends Wire {
 			}
 		}
 
-		if($this->superuser) {
+		if($user->hasPermission('page-delete', $page)) {
 			$trashIcon = "<i class='fa fa-trash-o'></i>&nbsp;";
 			if($page->trashable()) {
 				$extras['trash'] = array(


### PR DESCRIPTION
Allow all users with page-delete permission to thrash a page in the page list actions.