### PR TITLE
Proposal to implement ImageInspector

### DIFF
--- a/wire/core/ImageSizer.php
+++ b/wire/core/ImageSizer.php
@@ -362,10 +362,13 @@ class ImageSizer extends Wire {
 			case \IMAGETYPE_PNG:
 				$type = 'png';
 				$indexed = 'Indexed' == $this->inspectionResult['info']['colspace'] ? '8' : '24';
-				$trans = is_array($this->inspectionResult['info']['trans']) || $this->inspectionResult['info']['alpha'] ? '-trans' : '';
+				$trans = $this->inspectionResult['info']['alpha'] ? '-alpha' : '';
+				$trans = is_array($this->inspectionResult['info']['trans']) ? '-trans' : $trans;
 				$animated = '';
 				break;
 		}
+		#$orientation = '';
+		#if($this->inspectionResult['info']['orientation'] > 1 && $this->inspectionResult['info']['orientation'] < 9) $orientation = '-orient';
 		return $type . $indexed . $trans . $animated;
 	}
 

--- a/wire/core/ImageSizer.php
+++ b/wire/core/ImageSizer.php
@@ -175,7 +175,6 @@ class ImageSizer extends Wire {
 			$engine = $this->newDefaultImageSizerEngine($filename, $options, $inspectionResult);
 		}
 
-my_var_dump(array($this->getImageInfo(), $engine->className), 1);
 		return $engine;
 	}
 

--- a/wire/core/ImageSizer.php
+++ b/wire/core/ImageSizer.php
@@ -473,7 +473,7 @@ class ImageSizer extends Wire {
 		}
 		$info = getimagesize($filename);
 		if(\IMAGETYPE_GIF != $info[2]) return false;
-		if(ImageSizerEngineGD::checkMemoryForImage(array($info[0], $info[1]))) {
+		if(ImageSizerEngineGD::checkMemoryForImage(array($info['width'], $info['height']))) {
 			return (bool) preg_match('/\x00\x21\xF9\x04.{4}\x00(\x2C|\x21)/s', file_get_contents($filename));
 		}
 		// we have not enough free memory to load the complete image at once, so we do it in chunks

--- a/wire/core/ImageSizer.php
+++ b/wire/core/ImageSizer.php
@@ -150,8 +150,12 @@ class ImageSizer extends Wire {
 	protected function newImageSizerEngine($filename = '', array $options = array(), $inspectionResult = null) {
 		
 		if(empty($filename)) $filename = $this->filename;
-		if(empty($inspectionResult)) $inspectionResult = $this->inspectionResult;
 		if(empty($options)) $options = $this->initialOptions;
+		if(empty($inspectionResult)) $inspectionResult = $this->inspectionResult;
+		if($filename && is_readable($filename) && empty($inspectionResult)) {
+			$imageInspector = new ImageInspector($filename);
+			$this->inspectionResult = $inspectionResult = $imageInspector->inspect($filename, true);
+		}
 		
 		$engine = null;
 	
@@ -170,7 +174,8 @@ class ImageSizer extends Wire {
 			// fallback to default
 			$engine = $this->newDefaultImageSizerEngine($filename, $options, $inspectionResult);
 		}
-		
+
+my_var_dump(array($this->getImageInfo(), $engine->className), 1);
 		return $engine;
 	}
 
@@ -344,25 +349,25 @@ class ImageSizer extends Wire {
 		$imageType = $this->inspectionResult['info']['imageType'];
 		switch($imageType) {
 			case \IMAGETYPE_JPEG:
-				$extension = 'jpg';
+				$type = 'jpg';
 				$indexed = '';
 				$trans = '';
 				$animated = '';
 				break;
 			case \IMAGETYPE_GIF:
-				$extension = 'gif';
+				$type = 'gif';
 				$indexed = '';
 				$trans = $this->inspectionResult['info']['trans'] ? '-trans' : '';
 				$animated = $this->inspectionResult['info']['animated'] ? '-anim' : '';
 				break;
 			case \IMAGETYPE_PNG:
-				$extension = 'png';
+				$type = 'png';
 				$indexed = 'Indexed' == $this->inspectionResult['info']['colspace'] ? '8' : '24';
 				$trans = is_array($this->inspectionResult['info']['trans']) || $this->inspectionResult['info']['alpha'] ? '-trans' : '';
 				$animated = '';
 				break;
 		}
-		return $extension . $indexed . $trans . $animated;
+		return $type . $indexed . $trans . $animated;
 	}
 
 	/**

--- a/wire/core/ImageSizerEngine.php
+++ b/wire/core/ImageSizerEngine.php
@@ -342,6 +342,7 @@ abstract class ImageSizerEngine extends WireData implements Module, Configurable
 		$this->setTimeLimit();
 
 		// when invoked from Pageimage, $inspectionResult holds the InfoCollection from ImageInspector, otherwise NULL
+		// if it is invoked manually and its value is NULL, the method loadImageInfo() will fetch the infos
 		$this->inspectionResult = $inspectionResult;
 
 		// filling all options with global custom values from config.php
@@ -1150,6 +1151,40 @@ abstract class ImageSizerEngine extends WireData implements Module, Configurable
 	 */
 	public function getImageType() {
 		return $this->imageType;
+	}
+
+	/**
+	 * ImageInformation from Image Inspector
+	 * in short form or full RawInfoData
+	 *
+	 * @param bool $rawData
+	 * @return string|array
+	 *
+	 */
+	protected function getImageInfo($rawData = false) {
+		if($rawData) return $this->inspectionResult;
+		$imageType = $this->inspectionResult['info']['imageType'];
+		switch($imageType) {
+			case \IMAGETYPE_JPEG:
+				$type = 'jpg';
+				$indexed = '';
+				$trans = '';
+				$animated = '';
+				break;
+			case \IMAGETYPE_GIF:
+				$type = 'gif';
+				$indexed = '';
+				$trans = $this->inspectionResult['info']['trans'] ? '-trans' : '';
+				$animated = $this->inspectionResult['info']['animated'] ? '-anim' : '';
+				break;
+			case \IMAGETYPE_PNG:
+				$type = 'png';
+				$indexed = 'Indexed' == $this->inspectionResult['info']['colspace'] ? '8' : '24';
+				$trans = is_array($this->inspectionResult['info']['trans']) || $this->inspectionResult['info']['alpha'] ? '-trans' : '';
+				$animated = '';
+				break;
+		}
+		return $type . $indexed . $trans . $animated;
 	}
 
 	/**

--- a/wire/core/ImageSizerEngine.php
+++ b/wire/core/ImageSizerEngine.php
@@ -1259,15 +1259,10 @@ abstract class ImageSizerEngine extends WireData implements Module, Configurable
 			'7' => array(90, 1),
 			'8' => array(90, 0)
 		);
-		if(!function_exists('exif_read_data')) return false;
-		$exif = @exif_read_data($this->filename, 'IFD0');
-		if(!is_array($exif)
-			|| !isset($exif['Orientation'])
-			|| !in_array(strval($exif['Orientation']), array_keys($corrections))
-		) {
+		if(!isset($this->info['orientation']) || !isset($corrections[strval($this->info['orientation'])])) {
 			return false;
 		}
-		$correctionArray = $corrections[strval($exif['Orientation'])];
+		$correctionArray = $corrections[strval($this->info['orientation'])];
 		return true;
 	}
 

--- a/wire/core/ImageSizerEngine.php
+++ b/wire/core/ImageSizerEngine.php
@@ -363,7 +363,7 @@ abstract class ImageSizerEngine extends WireData implements Module, Configurable
 	 * @return bool
 	 *
 	 */
-	abstract public function supported($action = '');
+	abstract public function supported($action = 'imageformat');
 
 	/**
 	 * Process the image resize
@@ -1180,7 +1180,8 @@ abstract class ImageSizerEngine extends WireData implements Module, Configurable
 			case \IMAGETYPE_PNG:
 				$type = 'png';
 				$indexed = 'Indexed' == $this->inspectionResult['info']['colspace'] ? '8' : '24';
-				$trans = is_array($this->inspectionResult['info']['trans']) || $this->inspectionResult['info']['alpha'] ? '-trans' : '';
+				$trans = is_array($this->inspectionResult['info']['trans']) ? '-trans' : '';
+				$trans = $this->inspectionResult['info']['alpha'] ? '-alpha' : $trans;
 				$animated = '';
 				break;
 		}

--- a/wire/core/ImageSizerEngineGD.php
+++ b/wire/core/ImageSizerEngineGD.php
@@ -46,6 +46,7 @@ class ImageSizerEngineGD extends ImageSizerEngine {
 
 	/**
 	 * Return whether or not GD can proceed 
+	 * Is the current image(sub)format supported?
 	 * 
 	 * @param string $action
 	 * @return bool
@@ -53,6 +54,16 @@ class ImageSizerEngineGD extends ImageSizerEngine {
 	 */
 	public function supported($action = '') {
 		if(!function_exists('gd_info')) return false;
+		// compare current imagefile infos fetched from ImageInspector
+		$requested = $this->getImageInfo(false);
+		switch($requested) {
+			case 'gif-anim':
+			case 'gif-trans-anim':
+				// Animated GIF images are not supported, but GD will render the first iamge of the animation
+				#return false;
+			default:
+				return true;
+		}
 		/*
 		$gd  = gd_info();
 		$jpg = isset($gd['JPEG Support']) ? $gd['JPEG Support'] : false;
@@ -61,7 +72,6 @@ class ImageSizerEngineGD extends ImageSizerEngine {
 		$freetype = isset($gd['FreeType Support']) ? $gd['FreeType Support'] : false;
 		$this->config->gdReady = true;
 		*/
-		return true;
 	}
 
 	/**
@@ -448,7 +458,7 @@ class ImageSizerEngineGD extends ImageSizerEngine {
 	/**
 	 * Unsharp Mask for PHP - version 2.1.1
 	 *
-	 * Unsharp mask algorithm by Torstein Hønsi 2003-07.
+	 * Unsharp mask algorithm by Torstein HÃ¸nsi 2003-07.
 	 * thoensi_at_netcom_dot_no.
 	 * Please leave this notice.
 	 *

--- a/wire/core/ImageSizerEngineGD.php
+++ b/wire/core/ImageSizerEngineGD.php
@@ -52,26 +52,41 @@ class ImageSizerEngineGD extends ImageSizerEngine {
 	 * @return bool
 	 * 
 	 */
-	public function supported($action = '') {
+	public function supported($action = 'imageformat') {
+
+		// first we check parts that are mandatory for all $actions
 		if(!function_exists('gd_info')) return false;
-		// compare current imagefile infos fetched from ImageInspector
-		$requested = $this->getImageInfo(false);
-		switch($requested) {
-			case 'gif-anim':
-			case 'gif-trans-anim':
-				// Animated GIF images are not supported, but GD will render the first iamge of the animation
-				#return false;
-			default:
+
+		// and if it passes the mandatory requirements, we check particularly aspects here
+		switch($action) {
+			
+			case 'imageformat':
+				// compare current imagefile infos fetched from ImageInspector
+				$requested = $this->getImageInfo(false);
+				switch($requested) {
+					case 'gif-anim':
+					case 'gif-trans-anim':
+						// Animated GIF images are not supported, but GD renders the first image of the animation
+						#return false;
+					default:
+						return true;
+				}
+				break;
+			
+			case 'install':
+				/*
+				$gd  = gd_info();
+				$jpg = isset($gd['JPEG Support']) ? $gd['JPEG Support'] : false;
+				$png = isset($gd['PNG Support']) ? $gd['PNG Support'] : false;
+				$gif = isset($gd['GIF Read Support']) && isset($gd['GIF Create Support']) ? $gd['GIF Create Support'] : false;
+				$freetype = isset($gd['FreeType Support']) ? $gd['FreeType Support'] : false;
+				$this->config->gdReady = true;
+				*/
 				return true;
+			
+			default:
+				return false;
 		}
-		/*
-		$gd  = gd_info();
-		$jpg = isset($gd['JPEG Support']) ? $gd['JPEG Support'] : false;
-		$png = isset($gd['PNG Support']) ? $gd['PNG Support'] : false;
-		$gif = isset($gd['GIF Read Support']) && isset($gd['GIF Create Support']) ? $gd['GIF Create Support'] : false;
-		$freetype = isset($gd['FreeType Support']) ? $gd['FreeType Support'] : false;
-		$this->config->gdReady = true;
-		*/
 	}
 
 	/**
@@ -458,7 +473,7 @@ class ImageSizerEngineGD extends ImageSizerEngine {
 	/**
 	 * Unsharp Mask for PHP - version 2.1.1
 	 *
-	 * Unsharp mask algorithm by Torstein HÃ¸nsi 2003-07.
+	 * Unsharp mask algorithm by Torstein Hønsi 2003-07.
 	 * thoensi_at_netcom_dot_no.
 	 * Please leave this notice.
 	 *

--- a/wire/core/ImageSizerEngineGD.php
+++ b/wire/core/ImageSizerEngineGD.php
@@ -118,7 +118,7 @@ class ImageSizerEngineGD extends ImageSizerEngine {
 		(!empty($orientations[0]) || !empty($orientations[1])) ? true : false);
 
 		// check if we can load the sourceimage into ram
-		if(self::checkMemoryForImage(array($this->info[0], $this->info[1], $this->info['channels'])) === false) {
+		if(self::checkMemoryForImage(array($this->info['width'], $this->info['height'], $this->info['channels'])) === false) {
 			throw new WireException(basename($srcFilename) . " - not enough memory to load");
 		}
 
@@ -164,7 +164,7 @@ class ImageSizerEngineGD extends ImageSizerEngine {
 		// if there is requested to crop _before_ resize, we do it here @horst
 		if(is_array($this->cropExtra)) {
 			// check if we can load a second copy from sourceimage into ram
-			if(self::checkMemoryForImage(array($this->info[0], $this->info[1], 3)) === false) {
+			if(self::checkMemoryForImage(array($this->info['width'], $this->info['height'], 3)) === false) {
 				throw new WireException(basename($srcFilename) . " - not enough memory to load a copy for cropExtra");
 			}
 

--- a/wire/modules/Image/ImageInspector/ImageInspector.module
+++ b/wire/modules/Image/ImageInspector/ImageInspector.module
@@ -6,17 +6,17 @@
  */
 class ImageInspector extends WireData implements Module, ConfigurableModule {
 
-    public static function getModuleInfo() {
-        return array(
-            'title' => 'Image Inspector',
-            'version' => 1,
-            'summary' => "Upgrades ImageSizer and ImageSizerEngines with more in depth information of imagefiles and -formats.",
-            'author' => 'Horst Nogajski',
-            #'permanent' => true,
-            'autoload' => false,
-            'singular' => false
-        );
-    }
+	public static function getModuleInfo() {
+		return array(
+			'title' => 'Image Inspector',
+			'version' => 2,
+			'summary' => "Upgrades ImageSizer and ImageSizerEngines with more in depth information of imagefiles and -formats.",
+			'author' => 'Horst Nogajski',
+			#'permanent' => true,
+			'autoload' => false,
+			'singular' => false
+		);
+	}
 
 	/**
 	 * Filename to be inspected
@@ -71,9 +71,9 @@ class ImageInspector extends WireData implements Module, ConfigurableModule {
 
 	public function __construct($filename = '') {
 		parent::__construct();
-        if($filename && is_readable($filename)) {
-            $this->filename = $filename;
-        }
+		if($filename && is_readable($filename)) {
+			$this->filename = $filename;
+		}
 	}
 
 
@@ -86,13 +86,13 @@ class ImageInspector extends WireData implements Module, ConfigurableModule {
 	 *
 	 */
 	public function inspect($filename = '', $parseAppmarker = false) {
-        if($filename) $this->filename = $filename;
-        if(!$this->filename || !is_readable($this->filename)) return null;
-	    if(!$this->extension) $this->extension = pathinfo($this->filename, \PATHINFO_EXTENSION);
+		if($filename) $this->filename = $filename;
+		if(!$this->filename || !is_readable($this->filename)) return null;
+		if(!$this->extension) $this->extension = pathinfo($this->filename, \PATHINFO_EXTENSION);
 		$this->extension = strtolower($this->extension);
 
 		$additionalInfo = array();
-        $info = @getimagesize($filename, $additionalInfo);
+		$info = @getimagesize($filename, $additionalInfo);
 		if($info === false) return false;
 
 		// read basic data
@@ -103,9 +103,9 @@ class ImageInspector extends WireData implements Module, ConfigurableModule {
 		} else if(isset($this->supportedImageTypes[$this->extension])) {
 			$imageType = $this->supportedImageTypes[$this->extension];
 		}
-        $this->info['width'] = $info[0];
-        $this->info['height'] = $info[1];
-        $this->info['imageType'] = $imageType;
+		$this->info['width'] = $info[0];
+		$this->info['height'] = $info[1];
+		$this->info['imageType'] = $imageType;
 		$this->info['mime'] = isset($this->supportedMimeTypes[$imageType]) ? $this->supportedMimeTypes[$imageType] : 'unsupported';
 
 		// additional, more indepth data
@@ -123,7 +123,7 @@ class ImageInspector extends WireData implements Module, ConfigurableModule {
 				break;
 		}
 		
-        // read appmarker metadata if present
+		// read appmarker metadata if present
 		$this->info['appmarker'] = $iptcRaw = null;
 		if(is_array($additionalInfo) && $parseAppmarker) {
 			$appmarker = array();
@@ -155,13 +155,13 @@ class ImageInspector extends WireData implements Module, ConfigurableModule {
 	 *
 	 */
 	protected function loadImageInfoPng() {
-        @require_once(__DIR__ . '/ImageInspectorPng.php');
-	    $png = new PWPNG();
-	    if(!$png->loadFile($this->filename)) {
-	        return false;
-	    }
-        $this->info = array_merge($this->info, $png->info);
-        unset($png);
+		@require_once(__DIR__ . '/ImageInspectorPng.php');
+		$png = new PWPNG();
+		if(!$png->loadFile($this->filename)) {
+			return false;
+		}
+		$this->info = array_merge($this->info, $png->info);
+		unset($png);
 		return true;
 	}
 
@@ -173,28 +173,28 @@ class ImageInspector extends WireData implements Module, ConfigurableModule {
 	 *
 	 */
 	protected function loadImageInfoGif() {
-        @require_once(__DIR__ . '/ImageInspectorGif.php');
-	    $gif = new PWGIF(false);  // passing true also loads BitmapData
+		@require_once(__DIR__ . '/ImageInspectorGif.php');
+		$gif = new PWGIF(false);  // passing true also loads BitmapData
 		$iIndex = 0;
-	    if(!$gif->loadFile($this->filename, $iIndex)) {
-	        return false;
-	    }
-        $gi  = $gif->m_img;         // = CGIFIMAGE
-        $gfh = $gif->m_gfh;         // = CGIFFILEHEADER
-        $gih = $gif->m_img->m_gih;  // = CGIFIMAGEHEADER
-        $i = $this->info;
-        $i['width']       = $gfh->m_nWidth;
-        $i['height']      = $gfh->m_nHeight;
-		$i['gifversion']  = $gfh->m_lpVer;
-        $i['animated']    = $gfh->m_bAnimated;
-        $i['delay']       = $gi->m_nDelay;
-		$i['trans']       = $gi->m_bTrans;
-		$i['transcolor']  = $gi->m_nTrans;
-		$i['bgcolor']     = $gfh->m_nBgColor;
-		$i['numcolors']   = $gfh->m_colorTable->m_nColors;
-		$i['interlace']   = $gih->m_bInterlace;
-        $this->info = $i;
-        unset($gif, $gih, $gfh, $gi, $i);
+		if(!$gif->loadFile($this->filename, $iIndex)) {
+			return false;
+		}
+		$gi  = $gif->m_img;			// = CGIFIMAGE
+		$gfh = $gif->m_gfh;			// = CGIFFILEHEADER
+		$gih = $gif->m_img->m_gih;	// = CGIFIMAGEHEADER
+		$i = $this->info;
+		$i['width']			= $gfh->m_nWidth;
+		$i['height']		= $gfh->m_nHeight;
+		$i['gifversion']	= $gfh->m_lpVer;
+		$i['animated']		= $gfh->m_bAnimated;
+		$i['delay']			= $gi->m_nDelay;
+		$i['trans']			= $gi->m_bTrans;
+		$i['transcolor']	= $gi->m_nTrans;
+		$i['bgcolor']		= $gfh->m_nBgColor;
+		$i['numcolors']		= $gfh->m_colorTable->m_nColors;
+		$i['interlace']		= $gih->m_bInterlace;
+		$this->info = $i;
+		unset($gif, $gih, $gfh, $gi, $i);
 		return true;
 		//    CGIFFILEHEADER
 		//        numColors = m_colorTable->m_nColors

--- a/wire/modules/Image/ImageInspector/ImageInspector.module
+++ b/wire/modules/Image/ImageInspector/ImageInspector.module
@@ -1,0 +1,334 @@
+<?php namespace ProcessWire;
+
+/**
+ * ImageInspector by Horst
+ *
+ */
+class ImageInspector extends WireData implements Module, ConfigurableModule {
+
+    public static function getModuleInfo() {
+        return array(
+            'title' => 'Image Inspector',
+            'version' => 1,
+            'summary' => "Upgrades ImageSizer and ImageSizerEngines with more in depth information of imagefiles and -formats.",
+            'author' => 'Horst Nogajski',
+            #'permanent' => true,
+            'autoload' => false,
+            'singular' => false
+        );
+    }
+
+	/**
+	 * Filename to be inspected
+	 *
+	 * @var string
+	 *
+	 */
+	protected $filename;
+
+	/**
+	 * Extension of filename
+	 *
+	 * @var string
+	 *
+	 */
+	protected $extension;
+
+	/**
+	 * Information about the image
+	 *
+	 * @var array|null
+	 *
+	 */
+	protected $info = null;
+    
+	/**
+	 * Supported image types
+	 *
+	 * @var array
+	 *
+	 */
+	protected $supportedImageTypes = array(
+		'gif' => \IMAGETYPE_GIF,
+		'jpg' => \IMAGETYPE_JPEG,
+		'jpeg' => \IMAGETYPE_JPEG,
+		'png' => \IMAGETYPE_PNG
+	);
+    
+	/**
+	 * Supported mime types
+	 *
+	 * @var array
+	 *
+	 */
+	protected $supportedMimeTypes = array(
+		\IMAGETYPE_GIF => 'image/gif',
+		\IMAGETYPE_JPEG => 'image/jpeg',
+		\IMAGETYPE_PNG => 'image/png'
+	);
+
+
+
+	public function __construct($filename = '') {
+		parent::__construct();
+        if($filename && is_readable($filename)) {
+            $this->filename = $filename;
+        }
+	}
+
+
+	/**
+	 * parse Image and return information
+	 *
+	 * @param string $filename the file we want to inspect
+	 * @param bool $parseAppmarker (IPTC), default is FALSE
+	 * @return null|false|array
+	 *
+	 */
+	public function inspect($filename = '', $parseAppmarker = false) {
+        if($filename) $this->filename = $filename;
+        if(!$this->filename || !is_readable($this->filename)) return null;
+	    if(!$this->extension) $this->extension = pathinfo($this->filename, \PATHINFO_EXTENSION);
+		$this->extension = strtolower($this->extension);
+
+		$additionalInfo = array();
+        $info = @getimagesize($filename, $additionalInfo);
+		if($info === false) return false;
+
+		// read basic data
+		if(isset($info[2])) {
+			$imageType = $info[2];
+		} else if(function_exists("exif_imagetype")) {
+			$imageType = exif_imagetype($this->filename);
+		} else if(isset($this->supportedImageTypes[$this->extension])) {
+			$imageType = $this->supportedImageTypes[$this->extension];
+		}
+        $this->info['width'] = $info[0];
+        $this->info['height'] = $info[1];
+        $this->info['imageType'] = $imageType;
+		$this->info['mime'] = isset($this->supportedMimeTypes[$imageType]) ? $this->supportedMimeTypes[$imageType] : 'unsupported';
+
+		// additional, more indepth data
+		$this->info['channels'] = isset($info['channels']) ? $info['channels'] : -1;
+		$this->info['bits'] = isset($info['bits']) ? $info['bits'] : -1;
+		switch($imageType) {
+			case \IMAGETYPE_GIF:
+				$this->loadImageInfoGif();
+				break;
+			case \IMAGETYPE_JPEG:
+				$this->loadImageInfoJpg();
+				break;
+			case \IMAGETYPE_PNG:
+				$this->loadImageInfoPng();
+				break;
+		}
+		
+        // read appmarker metadata if present
+		$this->info['appmarker'] = $iptcRaw = null;
+		if(is_array($additionalInfo) && $parseAppmarker) {
+			$appmarker = array();
+			foreach($additionalInfo as $k => $v) {
+				$appmarker[$k] = substr($v, 0, strpos($v, null));
+			}
+			$this->info['appmarker'] = $appmarker;
+			if(isset($additionalInfo['APP13'])) {
+				$iptc = iptcparse($additionalInfo['APP13']);
+				if(is_array($iptc)) $iptcRaw = $iptc;
+			}
+		}
+
+		// return the result
+		return array(
+			'filename' => $this->filename,
+			'extension' => $this->extension,
+			'imageType' => $imageType,
+			'info' => $this->info,
+			'iptcRaw' => $iptcRaw
+		);
+	}
+    
+	
+	/**
+	 * parse PNG Image and collect information into $this->info
+	 *
+	 * @return bool
+	 *
+	 */
+	protected function loadImageInfoPng() {
+        @require_once(__DIR__ . '/ImageInspectorPng.php');
+	    $png = new PWPNG();
+	    if(!$png->loadFile($this->filename)) {
+	        return false;
+	    }
+        $this->info = array_merge($this->info, $png->info);
+        unset($png);
+		return true;
+	}
+
+
+	/**
+	 * parse GIF Image and collect information into $this->info
+	 *
+	 * @return bool
+	 *
+	 */
+	protected function loadImageInfoGif() {
+        @require_once(__DIR__ . '/ImageInspectorGif.php');
+	    $gif = new PWGIF(false);  // passing true also loads BitmapData
+		$iIndex = 0;
+	    if(!$gif->loadFile($this->filename, $iIndex)) {
+	        return false;
+	    }
+        $gi  = $gif->m_img;         // = CGIFIMAGE
+        $gfh = $gif->m_gfh;         // = CGIFFILEHEADER
+        $gih = $gif->m_img->m_gih;  // = CGIFIMAGEHEADER
+        $i = $this->info;
+        $i['width']       = $gfh->m_nWidth;
+        $i['height']      = $gfh->m_nHeight;
+		$i['gifversion']  = $gfh->m_lpVer;
+        $i['animated']    = $gfh->m_bAnimated;
+        $i['delay']       = $gi->m_nDelay;
+		$i['trans']       = $gi->m_bTrans;
+		$i['transcolor']  = $gi->m_nTrans;
+		$i['bgcolor']     = $gfh->m_nBgColor;
+		$i['numcolors']   = $gfh->m_colorTable->m_nColors;
+		$i['interlace']   = $gih->m_bInterlace;
+        $this->info = $i;
+        unset($gif, $gih, $gfh, $gi, $i);
+		return true;
+		//    CGIFFILEHEADER
+		//        numColors = m_colorTable->m_nColors
+		//        m_lpVer
+		//        m_nWidth
+		//        m_nHeight
+		//        m_bGlobalClr
+		//        m_nColorRes
+		//        m_bSorted
+		//        m_nTableSize
+		//        m_nBgColor
+		//        m_nPixelRatio
+		//        m_bAnimated
+		//
+		//    CGIFIMAGEHEADER
+		//        m_nLeft
+		//        m_nTop
+		//        m_nWidth
+		//        m_nHeight
+		//        m_bLocalClr
+		//        m_bInterlace
+		//        m_bSorted
+		//        m_nTableSize
+		//        m_colorTable
+		//
+		//    CGIFIMAGE
+		//        m_disp
+		//        m_bUser
+		//        m_bTrans
+		//        m_nDelay
+		//        m_nTrans
+		//        m_lpComm
+	}
+
+    
+	/**
+	 * parse JPEG Image and collect information into $this->info
+	 *
+	 * @return bool
+	 *
+	 */
+	protected function loadImageInfoJpg() {}
+
+
+	/**
+	 * Module info: not-autoload
+	 * 
+	 * @return bool
+	 * 
+	 */
+	public function isAutoload() {
+		return false;
+	}
+
+	/**
+	 * Module info: not singular
+	 * 
+	 * @return bool
+	 * 
+	 */
+	public function isSingular() {
+		return false;
+	}
+
+	/**
+	 * Set module config data for ConfigurableModule interface
+	 * 
+	 * @param array $data
+	 * 
+	 */
+	public function setConfigData(array $data) {
+		if(count($data)) $this->moduleConfigData = $data;
+		foreach($data as $key => $value) {
+			if($key == 'sharpening') {
+				$this->setSharpening($value);
+			} else if($key == 'quality') {
+				$this->setQuality($value);
+			} else {
+				$this->set($key, $value);
+			}
+		}
+	}
+
+	/**
+	 * Get module config data
+	 * 
+	 * @return array
+	 * 
+	 */
+	public function getConfigData() {
+		return $this->moduleConfigData;
+	}
+
+	/**
+	 * Module configuration
+	 * 
+	 * @param InputfieldWrapper $inputfields
+	 * 
+	 */
+	public function getModuleConfigInputfields(InputfieldWrapper $inputfields) {
+		
+//		$f = $this->wire('modules')->get('InputfieldRadios');
+//		$f->attr('name', 'inspector_depth_jpg');
+//		$f->label = $this->_('JPEG');
+//		$f->addOption('medium', $this->_('medium'));
+//		$f->addOption('full', $this->_('full'));
+//		$f->optionColumns = 1;
+//		$f->attr('value', $this->inspector_depth_jpg);
+//		$f->icon = 'image';
+//		$f->width = 33;
+//		$inputfields->add($f);
+//		
+//		$f = $this->wire('modules')->get('InputfieldRadios');
+//		$f->attr('name', 'inspector_depth_png');
+//		$f->label = $this->_('PNG');
+//		$f->addOption('medium', $this->_('medium'));
+//		$f->addOption('full', $this->_('full'));
+//		$f->optionColumns = 1;
+//		$f->attr('value', $this->inspector_depth_png);
+//		$f->icon = 'image';
+//		$f->width = 34;
+//		$inputfields->add($f);
+//		
+//		$f = $this->wire('modules')->get('InputfieldRadios');
+//		$f->attr('name', 'inspector_depth_gif');
+//		$f->label = $this->_('GIF');
+//		$f->addOption('medium', $this->_('medium'));
+//		$f->addOption('full', $this->_('full'));
+//		$f->optionColumns = 1;
+//		$f->attr('value', $this->inspector_depth_gif);
+//		$f->icon = 'image';
+//		$f->width = 33;
+//		$inputfields->add($f);
+
+	}
+
+}

--- a/wire/modules/Image/ImageInspector/ImageInspector.module
+++ b/wire/modules/Image/ImageInspector/ImageInspector.module
@@ -1,15 +1,18 @@
 <?php namespace ProcessWire;
 
 /**
- * ImageInspector by Horst
- *
+ * Image Inspector
+ * 
+ * Copyright (C) 2016 by Horst Nogajski and Ryan Cramer
+ * This file licensed under Mozilla Public License v2.0 http://mozilla.org/MPL/2.0/
+ * 
  */
 class ImageInspector extends WireData implements Module, ConfigurableModule {
 
 	public static function getModuleInfo() {
 		return array(
 			'title' => 'Image Inspector',
-			'version' => 2,
+			'version' => 3,
 			'summary' => "Upgrades ImageSizer and ImageSizerEngines with more in depth information of imagefiles and -formats.",
 			'author' => 'Horst Nogajski',
 			#'permanent' => true,
@@ -67,15 +70,13 @@ class ImageInspector extends WireData implements Module, ConfigurableModule {
 		\IMAGETYPE_PNG => 'image/png'
 	);
 
-
-
+	
 	public function __construct($filename = '') {
 		parent::__construct();
 		if($filename && is_readable($filename)) {
 			$this->filename = $filename;
 		}
 	}
-
 
 	/**
 	 * parse Image and return information
@@ -108,6 +109,12 @@ class ImageInspector extends WireData implements Module, ConfigurableModule {
 		$this->info['imageType'] = $imageType;
 		$this->info['mime'] = isset($this->supportedMimeTypes[$imageType]) ? $this->supportedMimeTypes[$imageType] : 'unsupported';
 
+		// Infos about Orientation and optional corrections for rotate and flip
+		$tmp = $this->checkOrientation($this->filename);
+		$this->info['orientation'] = $tmp['orientation'];  // Exif-Orientation value :: integer range 1 - 8, 0 on failure
+		$this->info['rotate'] = $tmp['rotate'];            // empty or 0 or degrees :: 0 | 90 | 180 | 270
+		$this->info['flip'] = $tmp['flip'];                // empty | horizontal | vertical :: 0 | 1 | 2
+		
 		// additional, more indepth data
 		$this->info['channels'] = isset($info['channels']) ? $info['channels'] : -1;
 		$this->info['bits'] = isset($info['bits']) ? $info['bits'] : -1;
@@ -146,7 +153,44 @@ class ImageInspector extends WireData implements Module, ConfigurableModule {
 			'iptcRaw' => $iptcRaw
 		);
 	}
-    
+
+	/**
+	 * Check orientation (@horst)
+	 *
+	 * @param array
+	 *
+	 * @return bool
+	 *
+	 */
+	protected function checkOrientation($filename) {
+		// first value is rotation-degree and second value is flip-mode: 0=NONE | 1=HORIZONTAL | 2=VERTICAL
+		$corrections = array(
+			'1' => array(0, 0),
+			'2' => array(0, 1),
+			'3' => array(180, 0),
+			'4' => array(0, 2),
+			'5' => array(270, 1),
+			'6' => array(270, 0),
+			'7' => array(90, 1),
+			'8' => array(90, 0)
+		);
+		$result = array('orientation' => 0, 'rotate' => 0, 'flip' => 0);
+		if(!function_exists('exif_read_data')) return $result;
+		$exif = @exif_read_data($filename, 'IFD0');
+		if(!is_array($exif)
+			|| !isset($exif['Orientation'])
+			|| !in_array(strval($exif['Orientation']), array_keys($corrections))
+		) {
+			return $result;
+		}
+		$correctionArray = $corrections[strval($exif['Orientation'])];
+		$result = array(
+			'orientation' => $exif['Orientation'],
+			'rotate' => $correctionArray[0],
+			'flip' => $correctionArray[1]
+			);
+		return $result;
+	}
 	
 	/**
 	 * parse PNG Image and collect information into $this->info
@@ -164,7 +208,6 @@ class ImageInspector extends WireData implements Module, ConfigurableModule {
 		unset($png);
 		return true;
 	}
-
 
 	/**
 	 * parse GIF Image and collect information into $this->info
@@ -228,7 +271,6 @@ class ImageInspector extends WireData implements Module, ConfigurableModule {
 		//        m_nTrans
 		//        m_lpComm
 	}
-
     
 	/**
 	 * parse JPEG Image and collect information into $this->info
@@ -237,7 +279,6 @@ class ImageInspector extends WireData implements Module, ConfigurableModule {
 	 *
 	 */
 	protected function loadImageInfoJpg() {}
-
 
 	/**
 	 * Module info: not-autoload

--- a/wire/modules/Image/ImageInspector/ImageInspectorGif.php
+++ b/wire/modules/Image/ImageInspector/ImageInspectorGif.php
@@ -15,206 +15,206 @@
 
 class PWGIFLZW {
 
-    public $MAX_LZW_BITS;
-    public $Fresh, $CodeSize, $SetCodeSize, $MaxCode, $MaxCodeSize, $FirstCode, $OldCode;
-    public $ClearCode, $EndCode, $Next, $Vals, $Stack, $sp, $Buf, $CurBit, $LastBit, $Done, $LastByte;
+	public $MAX_LZW_BITS;
+	public $Fresh, $CodeSize, $SetCodeSize, $MaxCode, $MaxCodeSize, $FirstCode, $OldCode;
+	public $ClearCode, $EndCode, $Next, $Vals, $Stack, $sp, $Buf, $CurBit, $LastBit, $Done, $LastByte;
 
 
-    public function __construct() {
-        $this->MAX_LZW_BITS = 12;
-        unSet($this->Next);
-        unSet($this->Vals);
-        unSet($this->Stack);
-        unSet($this->Buf);
+	public function __construct() {
+		$this->MAX_LZW_BITS = 12;
+		unSet($this->Next);
+		unSet($this->Vals);
+		unSet($this->Stack);
+		unSet($this->Buf);
 
-        $this->Next  = range(0, (1 << $this->MAX_LZW_BITS)       - 1);
-        $this->Vals  = range(0, (1 << $this->MAX_LZW_BITS)       - 1);
-        $this->Stack = range(0, (1 << ($this->MAX_LZW_BITS + 1)) - 1);
-        $this->Buf   = range(0, 279);
-    }
-
-
-    function deCompress($data, &$datLen) {
-        $stLen  = strlen($data);
-        $datLen = 0;
-        $ret    = '';
-
-        // INITIALIZATION
-        $this->LZWCommand($data, true);
-
-        while(($iIndex = $this->LZWCommand($data, false)) >= 0) {
-            $ret .= chr($iIndex);
-        }
-
-        $datLen = $stLen - strlen($data);
-
-        if($iIndex != -2) {
-            return false;
-        }
-
-        return $ret;
-    }
+		$this->Next  = range(0, (1 << $this->MAX_LZW_BITS)	   - 1);
+		$this->Vals  = range(0, (1 << $this->MAX_LZW_BITS)	   - 1);
+		$this->Stack = range(0, (1 << ($this->MAX_LZW_BITS + 1)) - 1);
+		$this->Buf   = range(0, 279);
+	}
 
 
-    function LZWCommand(&$data, $bInit) {
-        if($bInit) {
-            $this->SetCodeSize = ord($data{0});
-            $data = substr($data, 1);
+	function deCompress($data, &$datLen) {
+		$stLen  = strlen($data);
+		$datLen = 0;
+		$ret	= '';
 
-            $this->CodeSize    = $this->SetCodeSize + 1;
-            $this->ClearCode   = 1 << $this->SetCodeSize;
-            $this->EndCode     = $this->ClearCode + 1;
-            $this->MaxCode     = $this->ClearCode + 2;
-            $this->MaxCodeSize = $this->ClearCode << 1;
+		// INITIALIZATION
+		$this->LZWCommand($data, true);
 
-            $this->GetCode($data, $bInit);
+		while(($iIndex = $this->LZWCommand($data, false)) >= 0) {
+			$ret .= chr($iIndex);
+		}
 
-            $this->Fresh = 1;
-            for($i = 0; $i < $this->ClearCode; $i++) {
-                $this->Next[$i] = 0;
-                $this->Vals[$i] = $i;
-            }
+		$datLen = $stLen - strlen($data);
 
-            for(; $i < (1 << $this->MAX_LZW_BITS); $i++) {
-                $this->Next[$i] = 0;
-                $this->Vals[$i] = 0;
-            }
+		if($iIndex != -2) {
+			return false;
+		}
 
-            $this->sp = 0;
-            return 1;
-        }
-
-        if($this->Fresh) {
-            $this->Fresh = 0;
-            do {
-                $this->FirstCode = $this->GetCode($data, $bInit);
-                $this->OldCode   = $this->FirstCode;
-            }
-            while($this->FirstCode == $this->ClearCode);
-
-            return $this->FirstCode;
-        }
-
-        if($this->sp > 0) {
-            $this->sp--;
-            return $this->Stack[$this->sp];
-        }
-
-        while(($Code = $this->GetCode($data, $bInit)) >= 0) {
-            if($Code == $this->ClearCode) {
-                for($i = 0; $i < $this->ClearCode; $i++) {
-                    $this->Next[$i] = 0;
-                    $this->Vals[$i] = $i;
-                }
-
-                for(; $i < (1 << $this->MAX_LZW_BITS); $i++) {
-                    $this->Next[$i] = 0;
-                    $this->Vals[$i] = 0;
-                }
-
-                $this->CodeSize    = $this->SetCodeSize + 1;
-                $this->MaxCodeSize = $this->ClearCode << 1;
-                $this->MaxCode     = $this->ClearCode + 2;
-                $this->sp          = 0;
-                $this->FirstCode   = $this->GetCode($data, $bInit);
-                $this->OldCode     = $this->FirstCode;
-
-                return $this->FirstCode;
-            }
-
-            if($Code == $this->EndCode) {
-                return -2;
-            }
-
-            $InCode = $Code;
-            if($Code >= $this->MaxCode) {
-                $this->Stack[$this->sp] = $this->FirstCode;
-                $this->sp++;
-                $Code = $this->OldCode;
-            }
-
-            while($Code >= $this->ClearCode) {
-                $this->Stack[$this->sp] = $this->Vals[$Code];
-                $this->sp++;
-
-                if($Code == $this->Next[$Code]) // Circular table entry, big GIF Error!
-                    return -1;
-
-                $Code = $this->Next[$Code];
-            }
-
-            $this->FirstCode = $this->Vals[$Code];
-            $this->Stack[$this->sp] = $this->FirstCode;
-            $this->sp++;
-
-            if(($Code = $this->MaxCode) < (1 << $this->MAX_LZW_BITS)) {
-                $this->Next[$Code] = $this->OldCode;
-                $this->Vals[$Code] = $this->FirstCode;
-                $this->MaxCode++;
-
-                if(($this->MaxCode >= $this->MaxCodeSize) && ($this->MaxCodeSize < (1 << $this->MAX_LZW_BITS))) {
-                    $this->MaxCodeSize *= 2;
-                    $this->CodeSize++;
-                }
-            }
-
-            $this->OldCode = $InCode;
-            if($this->sp > 0) {
-                $this->sp--;
-                return $this->Stack[$this->sp];
-            }
-        }
-
-        return $Code;
-    }
+		return $ret;
+	}
 
 
-    function GetCode(&$data, $bInit) {
-        if($bInit) {
-            $this->CurBit   = 0;
-            $this->LastBit  = 0;
-            $this->Done     = 0;
-            $this->LastByte = 2;
-            return 1;
-        }
+	function LZWCommand(&$data, $bInit) {
+		if($bInit) {
+			$this->SetCodeSize = ord($data{0});
+			$data = substr($data, 1);
 
-        if(($this->CurBit + $this->CodeSize) >= $this->LastBit) {
-            if($this->Done) {
-                if($this->CurBit >= $this->LastBit) {
-                    // Ran off the end of my bits
-                    return 0;
-                }
-                return -1;
-            }
+			$this->CodeSize	= $this->SetCodeSize + 1;
+			$this->ClearCode   = 1 << $this->SetCodeSize;
+			$this->EndCode	 = $this->ClearCode + 1;
+			$this->MaxCode	 = $this->ClearCode + 2;
+			$this->MaxCodeSize = $this->ClearCode << 1;
 
-            $this->Buf[0] = $this->Buf[$this->LastByte - 2];
-            $this->Buf[1] = $this->Buf[$this->LastByte - 1];
+			$this->GetCode($data, $bInit);
 
-            $Count = ord($data{0});
-            $data  = substr($data, 1);
+			$this->Fresh = 1;
+			for($i = 0; $i < $this->ClearCode; $i++) {
+				$this->Next[$i] = 0;
+				$this->Vals[$i] = $i;
+			}
 
-            if($Count) {
-                for($i = 0; $i < $Count; $i++) {
-                    $this->Buf[2 + $i] = ord($data{$i});
-                }
-                $data = substr($data, $Count);
-            } else {
-                $this->Done = 1;
-            }
+			for(; $i < (1 << $this->MAX_LZW_BITS); $i++) {
+				$this->Next[$i] = 0;
+				$this->Vals[$i] = 0;
+			}
 
-            $this->LastByte = 2 + $Count;
-            $this->CurBit   = ($this->CurBit - $this->LastBit) + 16;
-            $this->LastBit  = (2 + $Count) << 3;
-        }
+			$this->sp = 0;
+			return 1;
+		}
 
-        $iRet = 0;
-        for($i = $this->CurBit, $j = 0; $j < $this->CodeSize; $i++, $j++) {
-            $iRet |= (($this->Buf[intval($i / 8)] & (1 << ($i % 8))) != 0) << $j;
-        }
+		if($this->Fresh) {
+			$this->Fresh = 0;
+			do {
+				$this->FirstCode = $this->GetCode($data, $bInit);
+				$this->OldCode   = $this->FirstCode;
+			}
+			while($this->FirstCode == $this->ClearCode);
 
-        $this->CurBit += $this->CodeSize;
-        return $iRet;
-    }
+			return $this->FirstCode;
+		}
+
+		if($this->sp > 0) {
+			$this->sp--;
+			return $this->Stack[$this->sp];
+		}
+
+		while(($Code = $this->GetCode($data, $bInit)) >= 0) {
+			if($Code == $this->ClearCode) {
+				for($i = 0; $i < $this->ClearCode; $i++) {
+					$this->Next[$i] = 0;
+					$this->Vals[$i] = $i;
+				}
+
+				for(; $i < (1 << $this->MAX_LZW_BITS); $i++) {
+					$this->Next[$i] = 0;
+					$this->Vals[$i] = 0;
+				}
+
+				$this->CodeSize	= $this->SetCodeSize + 1;
+				$this->MaxCodeSize = $this->ClearCode << 1;
+				$this->MaxCode	 = $this->ClearCode + 2;
+				$this->sp		  = 0;
+				$this->FirstCode   = $this->GetCode($data, $bInit);
+				$this->OldCode	 = $this->FirstCode;
+
+				return $this->FirstCode;
+			}
+
+			if($Code == $this->EndCode) {
+				return -2;
+			}
+
+			$InCode = $Code;
+			if($Code >= $this->MaxCode) {
+				$this->Stack[$this->sp] = $this->FirstCode;
+				$this->sp++;
+				$Code = $this->OldCode;
+			}
+
+			while($Code >= $this->ClearCode) {
+				$this->Stack[$this->sp] = $this->Vals[$Code];
+				$this->sp++;
+
+				if($Code == $this->Next[$Code]) // Circular table entry, big GIF Error!
+					return -1;
+
+				$Code = $this->Next[$Code];
+			}
+
+			$this->FirstCode = $this->Vals[$Code];
+			$this->Stack[$this->sp] = $this->FirstCode;
+			$this->sp++;
+
+			if(($Code = $this->MaxCode) < (1 << $this->MAX_LZW_BITS)) {
+				$this->Next[$Code] = $this->OldCode;
+				$this->Vals[$Code] = $this->FirstCode;
+				$this->MaxCode++;
+
+				if(($this->MaxCode >= $this->MaxCodeSize) && ($this->MaxCodeSize < (1 << $this->MAX_LZW_BITS))) {
+					$this->MaxCodeSize *= 2;
+					$this->CodeSize++;
+				}
+			}
+
+			$this->OldCode = $InCode;
+			if($this->sp > 0) {
+				$this->sp--;
+				return $this->Stack[$this->sp];
+			}
+		}
+
+		return $Code;
+	}
+
+
+	function GetCode(&$data, $bInit) {
+		if($bInit) {
+			$this->CurBit   = 0;
+			$this->LastBit  = 0;
+			$this->Done	 = 0;
+			$this->LastByte = 2;
+			return 1;
+		}
+
+		if(($this->CurBit + $this->CodeSize) >= $this->LastBit) {
+			if($this->Done) {
+				if($this->CurBit >= $this->LastBit) {
+					// Ran off the end of my bits
+					return 0;
+				}
+				return -1;
+			}
+
+			$this->Buf[0] = $this->Buf[$this->LastByte - 2];
+			$this->Buf[1] = $this->Buf[$this->LastByte - 1];
+
+			$Count = ord($data{0});
+			$data  = substr($data, 1);
+
+			if($Count) {
+				for($i = 0; $i < $Count; $i++) {
+					$this->Buf[2 + $i] = ord($data{$i});
+				}
+				$data = substr($data, $Count);
+			} else {
+				$this->Done = 1;
+			}
+
+			$this->LastByte = 2 + $Count;
+			$this->CurBit   = ($this->CurBit - $this->LastBit) + 16;
+			$this->LastBit  = (2 + $Count) << 3;
+		}
+
+		$iRet = 0;
+		for($i = $this->CurBit, $j = 0; $j < $this->CodeSize; $i++, $j++) {
+			$iRet |= (($this->Buf[intval($i / 8)] & (1 << ($i % 8))) != 0) << $j;
+		}
+
+		$this->CurBit += $this->CodeSize;
+		return $iRet;
+	}
 
 }
 
@@ -222,60 +222,60 @@ class PWGIFLZW {
 
 class PWGIFCOLORTABLE {
 
-    public $m_nColors;
-    public $m_arColors;
-    protected $extended;
+	public $m_nColors;
+	public $m_arColors;
+	protected $extended;
 
 
-    public function __construct($extended = false) {
-        unSet($this->m_nColors);
-        unSet($this->m_arColors);
-        $this->extended = $extended;
-    }
+	public function __construct($extended = false) {
+		unSet($this->m_nColors);
+		unSet($this->m_arColors);
+		$this->extended = $extended;
+	}
 
 
-    public function load($lpData, $num) {
-        $this->m_nColors  = 0;
-        $this->m_arColors = array();
+	public function load($lpData, $num) {
+		$this->m_nColors  = 0;
+		$this->m_arColors = array();
 
-        for($i = 0; $i < $num; $i++) {
-            $rgb = substr($lpData, $i * 3, 3);
-            if(strlen($rgb) < 3) {
-                return false;
-            }
-            if($this->extended) {
-                $this->m_arColors[] = (ord($rgb{2}) << 16) + (ord($rgb{1}) << 8) + ord($rgb{0});
-            }
-            $this->m_nColors++;
-        }
+		for($i = 0; $i < $num; $i++) {
+			$rgb = substr($lpData, $i * 3, 3);
+			if(strlen($rgb) < 3) {
+				return false;
+			}
+			if($this->extended) {
+				$this->m_arColors[] = (ord($rgb{2}) << 16) + (ord($rgb{1}) << 8) + ord($rgb{0});
+			}
+			$this->m_nColors++;
+		}
 
-        return true;
-    }
-
-
-            public function toString() {
-                $ret = '';
-                for($i = 0; $i < $this->m_nColors; $i++) {
-                    $ret .=
-                        chr(($this->m_arColors[$i] & 0x000000FF))       . // R
-                        chr(($this->m_arColors[$i] & 0x0000FF00) >>  8) . // G
-                        chr(($this->m_arColors[$i] & 0x00FF0000) >> 16);  // B
-                }
-                return $ret;
-            }
+		return true;
+	}
 
 
-            public function toRGBQuad() {
-                $ret = '';
-                for($i = 0; $i < $this->m_nColors; $i++) {
-                    $ret .=
-                        chr(($this->m_arColors[$i] & 0x00FF0000) >> 16) . // B
-                        chr(($this->m_arColors[$i] & 0x0000FF00) >>  8) . // G
-                        chr(($this->m_arColors[$i] & 0x000000FF))       . // R
-                        "\x00";
-                }
-                return $ret;
-            }
+			public function toString() {
+				$ret = '';
+				for($i = 0; $i < $this->m_nColors; $i++) {
+					$ret .=
+						chr(($this->m_arColors[$i] & 0x000000FF))	   . // R
+						chr(($this->m_arColors[$i] & 0x0000FF00) >>  8) . // G
+						chr(($this->m_arColors[$i] & 0x00FF0000) >> 16);  // B
+				}
+				return $ret;
+			}
+
+
+			public function toRGBQuad() {
+				$ret = '';
+				for($i = 0; $i < $this->m_nColors; $i++) {
+					$ret .=
+						chr(($this->m_arColors[$i] & 0x00FF0000) >> 16) . // B
+						chr(($this->m_arColors[$i] & 0x0000FF00) >>  8) . // G
+						chr(($this->m_arColors[$i] & 0x000000FF))	   . // R
+						"\x00";
+				}
+				return $ret;
+			}
 
 }
 
@@ -283,79 +283,79 @@ class PWGIFCOLORTABLE {
 
 class PWGIFFILEHEADER {
 
-    public $m_lpVer;
-    public $m_nWidth;
-    public $m_nHeight;
-    public $m_bGlobalClr;
-    public $m_nColorRes;
-    public $m_bSorted;
-    public $m_nTableSize;
-    public $m_nBgColor;
-    public $m_nPixelRatio;
-    public $m_colorTable;
-    public $m_bAnimated;   // @Horst: added property
-    protected $extended;
+	public $m_lpVer;
+	public $m_nWidth;
+	public $m_nHeight;
+	public $m_bGlobalClr;
+	public $m_nColorRes;
+	public $m_bSorted;
+	public $m_nTableSize;
+	public $m_nBgColor;
+	public $m_nPixelRatio;
+	public $m_colorTable;
+	public $m_bAnimated;   // @Horst: added property
+	protected $extended;
 
 
-    public function __construct($extended = false) {
-        unSet($this->m_lpVer);
-        unSet($this->m_nWidth);
-        unSet($this->m_nHeight);
-        unSet($this->m_bGlobalClr);
-        unSet($this->m_nColorRes);
-        unSet($this->m_bSorted);
-        unSet($this->m_nTableSize);
-        unSet($this->m_nBgColor);
-        unSet($this->m_nPixelRatio);
-        unSet($this->m_colorTable);
-        unSet($this->m_bAnimated);
-        $this->extended = $extended;
-    }
+	public function __construct($extended = false) {
+		unSet($this->m_lpVer);
+		unSet($this->m_nWidth);
+		unSet($this->m_nHeight);
+		unSet($this->m_bGlobalClr);
+		unSet($this->m_nColorRes);
+		unSet($this->m_bSorted);
+		unSet($this->m_nTableSize);
+		unSet($this->m_nBgColor);
+		unSet($this->m_nPixelRatio);
+		unSet($this->m_colorTable);
+		unSet($this->m_bAnimated);
+		$this->extended = $extended;
+	}
 
 
-    public function load($lpData, &$hdrLen) {
-        $hdrLen = 0;
+	public function load($lpData, &$hdrLen) {
+		$hdrLen = 0;
 
-        $this->m_lpVer = substr($lpData, 0, 6);
-        if(($this->m_lpVer <> 'GIF87a') && ($this->m_lpVer <> 'GIF89a')) {
-            return false;
-        }
+		$this->m_lpVer = substr($lpData, 0, 6);
+		if(($this->m_lpVer <> 'GIF87a') && ($this->m_lpVer <> 'GIF89a')) {
+			return false;
+		}
 
-        // @Horst: store if we have more then one animation frames
-        $this->m_bAnimated = 1 < preg_match_all('#\x00\x21\xF9\x04.{4}\x00(\x2C|\x21)#s', $lpData);
+		// @Horst: store if we have more then one animation frames
+		$this->m_bAnimated = 1 < preg_match_all('#\x00\x21\xF9\x04.{4}\x00(\x2C|\x21)#s', $lpData);
 
-        $this->m_nWidth  = $this->w2i(substr($lpData, 6, 2));
-        $this->m_nHeight = $this->w2i(substr($lpData, 8, 2));
-        if(!$this->m_nWidth || !$this->m_nHeight) {
-            return false;
-        }
+		$this->m_nWidth  = $this->w2i(substr($lpData, 6, 2));
+		$this->m_nHeight = $this->w2i(substr($lpData, 8, 2));
+		if(!$this->m_nWidth || !$this->m_nHeight) {
+			return false;
+		}
 
-        $b = ord(substr($lpData, 10, 1));
-        $this->m_bGlobalClr  = ($b & 0x80) ? true : false;
-        $this->m_nColorRes   = ($b & 0x70) >> 4;
-        $this->m_bSorted     = ($b & 0x08) ? true : false;
-        $this->m_nTableSize  = 2 << ($b & 0x07);
-        $this->m_nBgColor    = ord(substr($lpData, 11, 1));
-        $this->m_nPixelRatio = ord(substr($lpData, 12, 1));
-        $hdrLen = 13;
+		$b = ord(substr($lpData, 10, 1));
+		$this->m_bGlobalClr  = ($b & 0x80) ? true : false;
+		$this->m_nColorRes   = ($b & 0x70) >> 4;
+		$this->m_bSorted	 = ($b & 0x08) ? true : false;
+		$this->m_nTableSize  = 2 << ($b & 0x07);
+		$this->m_nBgColor	= ord(substr($lpData, 11, 1));
+		$this->m_nPixelRatio = ord(substr($lpData, 12, 1));
+		$hdrLen = 13;
 
-        if($this->m_bGlobalClr) {
-            $this->m_colorTable = new PWGIFCOLORTABLE($this->extended);
-            $tmp1 = $this->m_nTableSize;
-            if(!$this->m_colorTable->load(substr($lpData, $hdrLen), $tmp1)) {
-                return false;
-            }
-            $this->m_nTableSize = $tmp1;
-            $hdrLen += 3 * $this->m_nTableSize;
-        }
+		if($this->m_bGlobalClr) {
+			$this->m_colorTable = new PWGIFCOLORTABLE($this->extended);
+			$tmp1 = $this->m_nTableSize;
+			if(!$this->m_colorTable->load(substr($lpData, $hdrLen), $tmp1)) {
+				return false;
+			}
+			$this->m_nTableSize = $tmp1;
+			$hdrLen += 3 * $this->m_nTableSize;
+		}
 
-        return true;
-    }
+		return true;
+	}
 
 
-    private function w2i($str) {
-        return ord(substr($str, 0, 1)) + (ord(substr($str, 1, 1)) << 8);
-    }
+	private function w2i($str) {
+		return ord(substr($str, 0, 1)) + (ord(substr($str, 1, 1)) << 8);
+	}
 
 }
 
@@ -363,66 +363,66 @@ class PWGIFFILEHEADER {
 
 class PWGIFIMAGEHEADER {
 
-    public $m_nLeft;
-    public $m_nTop;
-    public $m_nWidth;
-    public $m_nHeight;
-    public $m_bLocalClr;
-    public $m_bInterlace;
-    public $m_bSorted;
-    public $m_nTableSize;
-    public $m_colorTable;
-    protected $extended;
+	public $m_nLeft;
+	public $m_nTop;
+	public $m_nWidth;
+	public $m_nHeight;
+	public $m_bLocalClr;
+	public $m_bInterlace;
+	public $m_bSorted;
+	public $m_nTableSize;
+	public $m_colorTable;
+	protected $extended;
 
 
-    public function __construct($extended = false) {
-        unSet($this->m_nLeft);
-        unSet($this->m_nTop);
-        unSet($this->m_nWidth);
-        unSet($this->m_nHeight);
-        unSet($this->m_bLocalClr);
-        unSet($this->m_bInterlace);
-        unSet($this->m_bSorted);
-        unSet($this->m_nTableSize);
-        unSet($this->m_colorTable);
-        $this->extended = $extended;
-    }
+	public function __construct($extended = false) {
+		unSet($this->m_nLeft);
+		unSet($this->m_nTop);
+		unSet($this->m_nWidth);
+		unSet($this->m_nHeight);
+		unSet($this->m_bLocalClr);
+		unSet($this->m_bInterlace);
+		unSet($this->m_bSorted);
+		unSet($this->m_nTableSize);
+		unSet($this->m_colorTable);
+		$this->extended = $extended;
+	}
 
 
-    public function load($lpData, &$hdrLen) {
-        $hdrLen = 0;
+	public function load($lpData, &$hdrLen) {
+		$hdrLen = 0;
 
-        $this->m_nLeft   = $this->w2i(substr($lpData, 0, 2));
-        $this->m_nTop    = $this->w2i(substr($lpData, 2, 2));
-        $this->m_nWidth  = $this->w2i(substr($lpData, 4, 2));
-        $this->m_nHeight = $this->w2i(substr($lpData, 6, 2));
+		$this->m_nLeft   = $this->w2i(substr($lpData, 0, 2));
+		$this->m_nTop	= $this->w2i(substr($lpData, 2, 2));
+		$this->m_nWidth  = $this->w2i(substr($lpData, 4, 2));
+		$this->m_nHeight = $this->w2i(substr($lpData, 6, 2));
 
-        if(!$this->m_nWidth || !$this->m_nHeight) {
-            return false;
-        }
+		if(!$this->m_nWidth || !$this->m_nHeight) {
+			return false;
+		}
 
-        $b = ord($lpData{8});
-        $this->m_bLocalClr  = ($b & 0x80) ? true : false;
-        $this->m_bInterlace = ($b & 0x40) ? true : false;
-        $this->m_bSorted    = ($b & 0x20) ? true : false;
-        $this->m_nTableSize = 2 << ($b & 0x07);
-        $hdrLen = 9;
+		$b = ord($lpData{8});
+		$this->m_bLocalClr  = ($b & 0x80) ? true : false;
+		$this->m_bInterlace = ($b & 0x40) ? true : false;
+		$this->m_bSorted	= ($b & 0x20) ? true : false;
+		$this->m_nTableSize = 2 << ($b & 0x07);
+		$hdrLen = 9;
 
-        if($this->m_bLocalClr) {
-            $this->m_colorTable = new PWGIFCOLORTABLE($this->extended);
-            if(!$this->m_colorTable->load(substr($lpData, $hdrLen), $this->m_nTableSize)) {
-                return false;
-            }
-            $hdrLen += 3 * $this->m_nTableSize;
-        }
+		if($this->m_bLocalClr) {
+			$this->m_colorTable = new PWGIFCOLORTABLE($this->extended);
+			if(!$this->m_colorTable->load(substr($lpData, $hdrLen), $this->m_nTableSize)) {
+				return false;
+			}
+			$hdrLen += 3 * $this->m_nTableSize;
+		}
 
-        return true;
-    }
+		return true;
+	}
 
 
-    private function w2i($str) {
-        return ord(substr($str, 0, 1)) + (ord(substr($str, 1, 1)) << 8);
-    }
+	private function w2i($str) {
+		return ord(substr($str, 0, 1)) + (ord(substr($str, 1, 1)) << 8);
+	}
 
 }
 
@@ -430,173 +430,173 @@ class PWGIFIMAGEHEADER {
 
 class PWGIFIMAGE {
 
-    public $m_disp;
-    public $m_bUser;
-    public $m_bTrans;
-    public $m_nDelay;
-    public $m_nTrans;
-    public $m_lpComm;
-    public $m_gih;
-    public $m_data;
-    public $m_lzw;
-    protected $extended;      // @Horst: added flag
+	public $m_disp;
+	public $m_bUser;
+	public $m_bTrans;
+	public $m_nDelay;
+	public $m_nTrans;
+	public $m_lpComm;
+	public $m_gih;
+	public $m_data;
+	public $m_lzw;
+	protected $extended;	  // @Horst: added flag
 
 
-    public function __construct($extended = false) {
-        unSet($this->m_disp);
-        unSet($this->m_bUser);
-        unSet($this->m_bTrans);
-        unSet($this->m_nDelay);
-        unSet($this->m_nTrans);
-        unSet($this->m_lpComm);
-        unSet($this->m_data);
-        $this->m_gih = new PWGIFIMAGEHEADER($extended);
-        if($extended) $this->m_lzw = new PWGIFLZW();
-        $this->extended = $extended;
-    }
+	public function __construct($extended = false) {
+		unSet($this->m_disp);
+		unSet($this->m_bUser);
+		unSet($this->m_bTrans);
+		unSet($this->m_nDelay);
+		unSet($this->m_nTrans);
+		unSet($this->m_lpComm);
+		unSet($this->m_data);
+		$this->m_gih = new PWGIFIMAGEHEADER($extended);
+		if($extended) $this->m_lzw = new PWGIFLZW();
+		$this->extended = $extended;
+	}
 
 
-    public function load($data, &$datLen) {
-        $datLen = 0;
+	public function load($data, &$datLen) {
+		$datLen = 0;
 
-        while(true) {
-            $b = ord($data{0});
-            $data = substr($data, 1);
-            $datLen++;
+		while(true) {
+			$b = ord($data{0});
+			$data = substr($data, 1);
+			$datLen++;
 
-            switch($b) {
-            case 0x21: // Extension
-            	$len = 0;
-                if(!$this->skipExt($data, $len)) {
-                    return false;
-                }
-                $datLen += $len;
-                break;
+			switch($b) {
+			case 0x21: // Extension
+				$len = 0;
+				if(!$this->skipExt($data, $len)) {
+					return false;
+				}
+				$datLen += $len;
+				break;
 
-            case 0x2C: // Image
-                // LOAD HEADER & COLOR TABLE
-                $len = 0;
-                if(!$this->m_gih->load($data, $len)) {
-                    return false;
-                }
-                $data = substr($data, $len);
-                $datLen += $len;
+			case 0x2C: // Image
+				// LOAD HEADER & COLOR TABLE
+				$len = 0;
+				if(!$this->m_gih->load($data, $len)) {
+					return false;
+				}
+				$data = substr($data, $len);
+				$datLen += $len;
 
-                // @Horst: early return, because we only want to inspect the image,
-                // not alter its bitmap data
-                if(!$this->extended) {
-                    return true;
-                }
+				// @Horst: early return, because we only want to inspect the image,
+				// not alter its bitmap data
+				if(!$this->extended) {
+					return true;
+				}
 
-                        // ALLOC BUFFER
-                        $len = 0;
-                        if(!($this->m_data = $this->m_lzw->deCompress($data, $len))) {
-                            return false;
-                        }
-                        $data = substr($data, $len);
-                        $datLen += $len;
+						// ALLOC BUFFER
+						$len = 0;
+						if(!($this->m_data = $this->m_lzw->deCompress($data, $len))) {
+							return false;
+						}
+						$data = substr($data, $len);
+						$datLen += $len;
 
-                        if($this->m_gih->m_bInterlace) {
-                            $this->deInterlace();
-                        }
-                        return true;
+						if($this->m_gih->m_bInterlace) {
+							$this->deInterlace();
+						}
+						return true;
 
-            case 0x3B: // EOF
-            default:
-                return false;
-            }
-        }
-        return false;
-    }
-
-
-    function skipExt(&$data, &$extLen) {
-        $extLen = 0;
-
-        $b = ord($data{0});
-        $data = substr($data, 1);
-        $extLen++;
-
-        switch($b) {
-        case 0xF9: // Graphic Control
-            $b = ord($data{1});
-            $this->m_disp   = ($b & 0x1C) >> 2;
-            $this->m_bUser  = ($b & 0x02) ? true : false;
-            $this->m_bTrans = ($b & 0x01) ? true : false;
-            $this->m_nDelay = $this->w2i(substr($data, 2, 2));
-            $this->m_nTrans = ord($data{4});
-            break;
-
-        case 0xFE: // Comment
-            $this->m_lpComm = substr($data, 1, ord($data{0}));
-            break;
-
-        case 0x01: // Plain text
-            break;
-
-        case 0xFF: // Application
-            break;
-        }
-
-        // SKIP DEFAULT AS DEFS MAY CHANGE
-        $b = ord($data{0});
-        $data = substr($data, 1);
-        $extLen++;
-        while($b > 0) {
-            $data = substr($data, $b);
-            $extLen += $b;
-            $b    = ord($data{0});
-            $data = substr($data, 1);
-            $extLen++;
-        }
-        return true;
-    }
+			case 0x3B: // EOF
+			default:
+				return false;
+			}
+		}
+		return false;
+	}
 
 
-    private function w2i($str) {
-        return ord(substr($str, 0, 1)) + (ord(substr($str, 1, 1)) << 8);
-    }
+	function skipExt(&$data, &$extLen) {
+		$extLen = 0;
+
+		$b = ord($data{0});
+		$data = substr($data, 1);
+		$extLen++;
+
+		switch($b) {
+		case 0xF9: // Graphic Control
+			$b = ord($data{1});
+			$this->m_disp   = ($b & 0x1C) >> 2;
+			$this->m_bUser  = ($b & 0x02) ? true : false;
+			$this->m_bTrans = ($b & 0x01) ? true : false;
+			$this->m_nDelay = $this->w2i(substr($data, 2, 2));
+			$this->m_nTrans = ord($data{4});
+			break;
+
+		case 0xFE: // Comment
+			$this->m_lpComm = substr($data, 1, ord($data{0}));
+			break;
+
+		case 0x01: // Plain text
+			break;
+
+		case 0xFF: // Application
+			break;
+		}
+
+		// SKIP DEFAULT AS DEFS MAY CHANGE
+		$b = ord($data{0});
+		$data = substr($data, 1);
+		$extLen++;
+		while($b > 0) {
+			$data = substr($data, $b);
+			$extLen += $b;
+			$b	= ord($data{0});
+			$data = substr($data, 1);
+			$extLen++;
+		}
+		return true;
+	}
 
 
-    function deInterlace() {
-        $data = $this->m_data;
+	private function w2i($str) {
+		return ord(substr($str, 0, 1)) + (ord(substr($str, 1, 1)) << 8);
+	}
 
-        for($i = 0; $i < 4; $i++) {
-            switch($i) {
-            case 0:
-                $s = 8;
-                $y = 0;
-                break;
 
-            case 1:
-                $s = 8;
-                $y = 4;
-                break;
+	function deInterlace() {
+		$data = $this->m_data;
 
-            case 2:
-                $s = 4;
-                $y = 2;
-                break;
+		for($i = 0; $i < 4; $i++) {
+			switch($i) {
+			case 0:
+				$s = 8;
+				$y = 0;
+				break;
 
-            case 3:
-                $s = 2;
-                $y = 1;
-                break;
-            }
+			case 1:
+				$s = 8;
+				$y = 4;
+				break;
 
-            for(; $y < $this->m_gih->m_nHeight; $y += $s) {
-                $lne = substr($this->m_data, 0, $this->m_gih->m_nWidth);
-                $this->m_data = substr($this->m_data, $this->m_gih->m_nWidth);
+			case 2:
+				$s = 4;
+				$y = 2;
+				break;
 
-                $data =
-                    substr($data, 0, $y * $this->m_gih->m_nWidth) .
-                    $lne .
-                    substr($data, ($y + 1) * $this->m_gih->m_nWidth);
-            }
-        }
+			case 3:
+				$s = 2;
+				$y = 1;
+				break;
+			}
 
-        $this->m_data = $data;
-    }
+			for(; $y < $this->m_gih->m_nHeight; $y += $s) {
+				$lne = substr($this->m_data, 0, $this->m_gih->m_nWidth);
+				$this->m_data = substr($this->m_data, $this->m_gih->m_nWidth);
+
+				$data =
+					substr($data, 0, $y * $this->m_gih->m_nWidth) .
+					$lne .
+					substr($data, ($y + 1) * $this->m_gih->m_nWidth);
+			}
+		}
+
+		$this->m_data = $data;
+	}
 
 }
 
@@ -604,54 +604,54 @@ class PWGIFIMAGE {
 
 class PWGIF {
 
-    public $m_gfh;
-    public $m_lpData;
-    public $m_img;
-    public $m_bLoaded;
+	public $m_gfh;
+	public $m_lpData;
+	public $m_img;
+	public $m_bLoaded;
 
 
-    // @Horst: added param $extended
-    //  - true = it also loads and parse Bitmapdata
-    //  - false = it only loads Headerdata
-    public function __construct($extended = false) {
-        $this->m_gfh     = new PWGIFFILEHEADER($extended);
-        $this->m_img     = new PWGIFIMAGE($extended);
-        $this->m_lpData  = '';
-        $this->m_bLoaded = false;
-    }
+	// @Horst: added param $extended
+	//  - true = it also loads and parse Bitmapdata
+	//  - false = it only loads Headerdata
+	public function __construct($extended = false) {
+		$this->m_gfh	 = new PWGIFFILEHEADER($extended);
+		$this->m_img	 = new PWGIFIMAGE($extended);
+		$this->m_lpData  = '';
+		$this->m_bLoaded = false;
+	}
 
 
-    public function loadFile($lpszFileName, $iIndex) {
-        if($iIndex < 0) {
-            return false;
-        }
+	public function loadFile($lpszFileName, $iIndex) {
+		if($iIndex < 0) {
+			return false;
+		}
 
-        // READ FILE
-        if(!($fh = @fopen($lpszFileName, 'rb'))) {
-            return false;
-        }
-        $this->m_lpData = @fRead($fh, @fileSize($lpszFileName));
-        fclose($fh);
+		// READ FILE
+		if(!($fh = @fopen($lpszFileName, 'rb'))) {
+			return false;
+		}
+		$this->m_lpData = @fRead($fh, @fileSize($lpszFileName));
+		fclose($fh);
 
-        // GET FILE HEADER
-        $len = 0;
-        if(!$this->m_gfh->load($this->m_lpData, $len)) {
-            return false;
-        }
-        $this->m_lpData = substr($this->m_lpData, $len);
+		// GET FILE HEADER
+		$len = 0;
+		if(!$this->m_gfh->load($this->m_lpData, $len)) {
+			return false;
+		}
+		$this->m_lpData = substr($this->m_lpData, $len);
 
-        do {
-        	$imgLen = 0;
-            if(!$this->m_img->load($this->m_lpData, $imgLen)) {
-                return false;
-            }
-            $this->m_lpData = substr($this->m_lpData, $imgLen);
-        }
-        while($iIndex-- > 0);
+		do {
+			$imgLen = 0;
+			if(!$this->m_img->load($this->m_lpData, $imgLen)) {
+				return false;
+			}
+			$this->m_lpData = substr($this->m_lpData, $imgLen);
+		}
+		while($iIndex-- > 0);
 
-        $this->m_bLoaded = true;
-        return true;
-    }
+		$this->m_bLoaded = true;
+		return true;
+	}
 
 }
 

--- a/wire/modules/Image/ImageInspector/ImageInspectorGif.php
+++ b/wire/modules/Image/ImageInspector/ImageInspectorGif.php
@@ -1,0 +1,657 @@
+<?php namespace ProcessWire;
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// GIF Util - (C) 2003 Yamasoft (S/C)
+// http://www.yamasoft.com
+// All Rights Reserved
+// This file can be freely copied, distributed, modified, updated by anyone under the only
+// condition to leave the original address (Yamasoft, http://www.yamasoft.com) and this header.
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// GIF Inspector - April 2016 - Horst Nogajski
+// Original code by Fabien Ezber, modified by Horst Nogajski, to be used for image inspection only
+// for ProcessWire 3+ (http://processwire.com/)
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+
+class PWGIFLZW {
+
+    public $MAX_LZW_BITS;
+    public $Fresh, $CodeSize, $SetCodeSize, $MaxCode, $MaxCodeSize, $FirstCode, $OldCode;
+    public $ClearCode, $EndCode, $Next, $Vals, $Stack, $sp, $Buf, $CurBit, $LastBit, $Done, $LastByte;
+
+
+    public function __construct() {
+        $this->MAX_LZW_BITS = 12;
+        unSet($this->Next);
+        unSet($this->Vals);
+        unSet($this->Stack);
+        unSet($this->Buf);
+
+        $this->Next  = range(0, (1 << $this->MAX_LZW_BITS)       - 1);
+        $this->Vals  = range(0, (1 << $this->MAX_LZW_BITS)       - 1);
+        $this->Stack = range(0, (1 << ($this->MAX_LZW_BITS + 1)) - 1);
+        $this->Buf   = range(0, 279);
+    }
+
+
+    function deCompress($data, &$datLen) {
+        $stLen  = strlen($data);
+        $datLen = 0;
+        $ret    = '';
+
+        // INITIALIZATION
+        $this->LZWCommand($data, true);
+
+        while(($iIndex = $this->LZWCommand($data, false)) >= 0) {
+            $ret .= chr($iIndex);
+        }
+
+        $datLen = $stLen - strlen($data);
+
+        if($iIndex != -2) {
+            return false;
+        }
+
+        return $ret;
+    }
+
+
+    function LZWCommand(&$data, $bInit) {
+        if($bInit) {
+            $this->SetCodeSize = ord($data{0});
+            $data = substr($data, 1);
+
+            $this->CodeSize    = $this->SetCodeSize + 1;
+            $this->ClearCode   = 1 << $this->SetCodeSize;
+            $this->EndCode     = $this->ClearCode + 1;
+            $this->MaxCode     = $this->ClearCode + 2;
+            $this->MaxCodeSize = $this->ClearCode << 1;
+
+            $this->GetCode($data, $bInit);
+
+            $this->Fresh = 1;
+            for($i = 0; $i < $this->ClearCode; $i++) {
+                $this->Next[$i] = 0;
+                $this->Vals[$i] = $i;
+            }
+
+            for(; $i < (1 << $this->MAX_LZW_BITS); $i++) {
+                $this->Next[$i] = 0;
+                $this->Vals[$i] = 0;
+            }
+
+            $this->sp = 0;
+            return 1;
+        }
+
+        if($this->Fresh) {
+            $this->Fresh = 0;
+            do {
+                $this->FirstCode = $this->GetCode($data, $bInit);
+                $this->OldCode   = $this->FirstCode;
+            }
+            while($this->FirstCode == $this->ClearCode);
+
+            return $this->FirstCode;
+        }
+
+        if($this->sp > 0) {
+            $this->sp--;
+            return $this->Stack[$this->sp];
+        }
+
+        while(($Code = $this->GetCode($data, $bInit)) >= 0) {
+            if($Code == $this->ClearCode) {
+                for($i = 0; $i < $this->ClearCode; $i++) {
+                    $this->Next[$i] = 0;
+                    $this->Vals[$i] = $i;
+                }
+
+                for(; $i < (1 << $this->MAX_LZW_BITS); $i++) {
+                    $this->Next[$i] = 0;
+                    $this->Vals[$i] = 0;
+                }
+
+                $this->CodeSize    = $this->SetCodeSize + 1;
+                $this->MaxCodeSize = $this->ClearCode << 1;
+                $this->MaxCode     = $this->ClearCode + 2;
+                $this->sp          = 0;
+                $this->FirstCode   = $this->GetCode($data, $bInit);
+                $this->OldCode     = $this->FirstCode;
+
+                return $this->FirstCode;
+            }
+
+            if($Code == $this->EndCode) {
+                return -2;
+            }
+
+            $InCode = $Code;
+            if($Code >= $this->MaxCode) {
+                $this->Stack[$this->sp] = $this->FirstCode;
+                $this->sp++;
+                $Code = $this->OldCode;
+            }
+
+            while($Code >= $this->ClearCode) {
+                $this->Stack[$this->sp] = $this->Vals[$Code];
+                $this->sp++;
+
+                if($Code == $this->Next[$Code]) // Circular table entry, big GIF Error!
+                    return -1;
+
+                $Code = $this->Next[$Code];
+            }
+
+            $this->FirstCode = $this->Vals[$Code];
+            $this->Stack[$this->sp] = $this->FirstCode;
+            $this->sp++;
+
+            if(($Code = $this->MaxCode) < (1 << $this->MAX_LZW_BITS)) {
+                $this->Next[$Code] = $this->OldCode;
+                $this->Vals[$Code] = $this->FirstCode;
+                $this->MaxCode++;
+
+                if(($this->MaxCode >= $this->MaxCodeSize) && ($this->MaxCodeSize < (1 << $this->MAX_LZW_BITS))) {
+                    $this->MaxCodeSize *= 2;
+                    $this->CodeSize++;
+                }
+            }
+
+            $this->OldCode = $InCode;
+            if($this->sp > 0) {
+                $this->sp--;
+                return $this->Stack[$this->sp];
+            }
+        }
+
+        return $Code;
+    }
+
+
+    function GetCode(&$data, $bInit) {
+        if($bInit) {
+            $this->CurBit   = 0;
+            $this->LastBit  = 0;
+            $this->Done     = 0;
+            $this->LastByte = 2;
+            return 1;
+        }
+
+        if(($this->CurBit + $this->CodeSize) >= $this->LastBit) {
+            if($this->Done) {
+                if($this->CurBit >= $this->LastBit) {
+                    // Ran off the end of my bits
+                    return 0;
+                }
+                return -1;
+            }
+
+            $this->Buf[0] = $this->Buf[$this->LastByte - 2];
+            $this->Buf[1] = $this->Buf[$this->LastByte - 1];
+
+            $Count = ord($data{0});
+            $data  = substr($data, 1);
+
+            if($Count) {
+                for($i = 0; $i < $Count; $i++) {
+                    $this->Buf[2 + $i] = ord($data{$i});
+                }
+                $data = substr($data, $Count);
+            } else {
+                $this->Done = 1;
+            }
+
+            $this->LastByte = 2 + $Count;
+            $this->CurBit   = ($this->CurBit - $this->LastBit) + 16;
+            $this->LastBit  = (2 + $Count) << 3;
+        }
+
+        $iRet = 0;
+        for($i = $this->CurBit, $j = 0; $j < $this->CodeSize; $i++, $j++) {
+            $iRet |= (($this->Buf[intval($i / 8)] & (1 << ($i % 8))) != 0) << $j;
+        }
+
+        $this->CurBit += $this->CodeSize;
+        return $iRet;
+    }
+
+}
+
+
+
+class PWGIFCOLORTABLE {
+
+    public $m_nColors;
+    public $m_arColors;
+    protected $extended;
+
+
+    public function __construct($extended = false) {
+        unSet($this->m_nColors);
+        unSet($this->m_arColors);
+        $this->extended = $extended;
+    }
+
+
+    public function load($lpData, $num) {
+        $this->m_nColors  = 0;
+        $this->m_arColors = array();
+
+        for($i = 0; $i < $num; $i++) {
+            $rgb = substr($lpData, $i * 3, 3);
+            if(strlen($rgb) < 3) {
+                return false;
+            }
+            if($this->extended) {
+                $this->m_arColors[] = (ord($rgb{2}) << 16) + (ord($rgb{1}) << 8) + ord($rgb{0});
+            }
+            $this->m_nColors++;
+        }
+
+        return true;
+    }
+
+
+            public function toString() {
+                $ret = '';
+                for($i = 0; $i < $this->m_nColors; $i++) {
+                    $ret .=
+                        chr(($this->m_arColors[$i] & 0x000000FF))       . // R
+                        chr(($this->m_arColors[$i] & 0x0000FF00) >>  8) . // G
+                        chr(($this->m_arColors[$i] & 0x00FF0000) >> 16);  // B
+                }
+                return $ret;
+            }
+
+
+            public function toRGBQuad() {
+                $ret = '';
+                for($i = 0; $i < $this->m_nColors; $i++) {
+                    $ret .=
+                        chr(($this->m_arColors[$i] & 0x00FF0000) >> 16) . // B
+                        chr(($this->m_arColors[$i] & 0x0000FF00) >>  8) . // G
+                        chr(($this->m_arColors[$i] & 0x000000FF))       . // R
+                        "\x00";
+                }
+                return $ret;
+            }
+
+}
+
+
+
+class PWGIFFILEHEADER {
+
+    public $m_lpVer;
+    public $m_nWidth;
+    public $m_nHeight;
+    public $m_bGlobalClr;
+    public $m_nColorRes;
+    public $m_bSorted;
+    public $m_nTableSize;
+    public $m_nBgColor;
+    public $m_nPixelRatio;
+    public $m_colorTable;
+    public $m_bAnimated;   // @Horst: added property
+    protected $extended;
+
+
+    public function __construct($extended = false) {
+        unSet($this->m_lpVer);
+        unSet($this->m_nWidth);
+        unSet($this->m_nHeight);
+        unSet($this->m_bGlobalClr);
+        unSet($this->m_nColorRes);
+        unSet($this->m_bSorted);
+        unSet($this->m_nTableSize);
+        unSet($this->m_nBgColor);
+        unSet($this->m_nPixelRatio);
+        unSet($this->m_colorTable);
+        unSet($this->m_bAnimated);
+        $this->extended = $extended;
+    }
+
+
+    public function load($lpData, &$hdrLen) {
+        $hdrLen = 0;
+
+        $this->m_lpVer = substr($lpData, 0, 6);
+        if(($this->m_lpVer <> 'GIF87a') && ($this->m_lpVer <> 'GIF89a')) {
+            return false;
+        }
+
+        // @Horst: store if we have more then one animation frames
+        $this->m_bAnimated = 1 < preg_match_all('#\x00\x21\xF9\x04.{4}\x00(\x2C|\x21)#s', $lpData);
+
+        $this->m_nWidth  = $this->w2i(substr($lpData, 6, 2));
+        $this->m_nHeight = $this->w2i(substr($lpData, 8, 2));
+        if(!$this->m_nWidth || !$this->m_nHeight) {
+            return false;
+        }
+
+        $b = ord(substr($lpData, 10, 1));
+        $this->m_bGlobalClr  = ($b & 0x80) ? true : false;
+        $this->m_nColorRes   = ($b & 0x70) >> 4;
+        $this->m_bSorted     = ($b & 0x08) ? true : false;
+        $this->m_nTableSize  = 2 << ($b & 0x07);
+        $this->m_nBgColor    = ord(substr($lpData, 11, 1));
+        $this->m_nPixelRatio = ord(substr($lpData, 12, 1));
+        $hdrLen = 13;
+
+        if($this->m_bGlobalClr) {
+            $this->m_colorTable = new PWGIFCOLORTABLE($this->extended);
+            $tmp1 = $this->m_nTableSize;
+            if(!$this->m_colorTable->load(substr($lpData, $hdrLen), $tmp1)) {
+                return false;
+            }
+            $this->m_nTableSize = $tmp1;
+            $hdrLen += 3 * $this->m_nTableSize;
+        }
+
+        return true;
+    }
+
+
+    private function w2i($str) {
+        return ord(substr($str, 0, 1)) + (ord(substr($str, 1, 1)) << 8);
+    }
+
+}
+
+
+
+class PWGIFIMAGEHEADER {
+
+    public $m_nLeft;
+    public $m_nTop;
+    public $m_nWidth;
+    public $m_nHeight;
+    public $m_bLocalClr;
+    public $m_bInterlace;
+    public $m_bSorted;
+    public $m_nTableSize;
+    public $m_colorTable;
+    protected $extended;
+
+
+    public function __construct($extended = false) {
+        unSet($this->m_nLeft);
+        unSet($this->m_nTop);
+        unSet($this->m_nWidth);
+        unSet($this->m_nHeight);
+        unSet($this->m_bLocalClr);
+        unSet($this->m_bInterlace);
+        unSet($this->m_bSorted);
+        unSet($this->m_nTableSize);
+        unSet($this->m_colorTable);
+        $this->extended = $extended;
+    }
+
+
+    public function load($lpData, &$hdrLen) {
+        $hdrLen = 0;
+
+        $this->m_nLeft   = $this->w2i(substr($lpData, 0, 2));
+        $this->m_nTop    = $this->w2i(substr($lpData, 2, 2));
+        $this->m_nWidth  = $this->w2i(substr($lpData, 4, 2));
+        $this->m_nHeight = $this->w2i(substr($lpData, 6, 2));
+
+        if(!$this->m_nWidth || !$this->m_nHeight) {
+            return false;
+        }
+
+        $b = ord($lpData{8});
+        $this->m_bLocalClr  = ($b & 0x80) ? true : false;
+        $this->m_bInterlace = ($b & 0x40) ? true : false;
+        $this->m_bSorted    = ($b & 0x20) ? true : false;
+        $this->m_nTableSize = 2 << ($b & 0x07);
+        $hdrLen = 9;
+
+        if($this->m_bLocalClr) {
+            $this->m_colorTable = new PWGIFCOLORTABLE($this->extended);
+            if(!$this->m_colorTable->load(substr($lpData, $hdrLen), $this->m_nTableSize)) {
+                return false;
+            }
+            $hdrLen += 3 * $this->m_nTableSize;
+        }
+
+        return true;
+    }
+
+
+    private function w2i($str) {
+        return ord(substr($str, 0, 1)) + (ord(substr($str, 1, 1)) << 8);
+    }
+
+}
+
+
+
+class PWGIFIMAGE {
+
+    public $m_disp;
+    public $m_bUser;
+    public $m_bTrans;
+    public $m_nDelay;
+    public $m_nTrans;
+    public $m_lpComm;
+    public $m_gih;
+    public $m_data;
+    public $m_lzw;
+    protected $extended;      // @Horst: added flag
+
+
+    public function __construct($extended = false) {
+        unSet($this->m_disp);
+        unSet($this->m_bUser);
+        unSet($this->m_bTrans);
+        unSet($this->m_nDelay);
+        unSet($this->m_nTrans);
+        unSet($this->m_lpComm);
+        unSet($this->m_data);
+        $this->m_gih = new PWGIFIMAGEHEADER($extended);
+        if($extended) $this->m_lzw = new PWGIFLZW();
+        $this->extended = $extended;
+    }
+
+
+    public function load($data, &$datLen) {
+        $datLen = 0;
+
+        while(true) {
+            $b = ord($data{0});
+            $data = substr($data, 1);
+            $datLen++;
+
+            switch($b) {
+            case 0x21: // Extension
+            	$len = 0;
+                if(!$this->skipExt($data, $len)) {
+                    return false;
+                }
+                $datLen += $len;
+                break;
+
+            case 0x2C: // Image
+                // LOAD HEADER & COLOR TABLE
+                $len = 0;
+                if(!$this->m_gih->load($data, $len)) {
+                    return false;
+                }
+                $data = substr($data, $len);
+                $datLen += $len;
+
+                // @Horst: early return, because we only want to inspect the image,
+                // not alter its bitmap data
+                if(!$this->extended) {
+                    return true;
+                }
+
+                        // ALLOC BUFFER
+                        $len = 0;
+                        if(!($this->m_data = $this->m_lzw->deCompress($data, $len))) {
+                            return false;
+                        }
+                        $data = substr($data, $len);
+                        $datLen += $len;
+
+                        if($this->m_gih->m_bInterlace) {
+                            $this->deInterlace();
+                        }
+                        return true;
+
+            case 0x3B: // EOF
+            default:
+                return false;
+            }
+        }
+        return false;
+    }
+
+
+    function skipExt(&$data, &$extLen) {
+        $extLen = 0;
+
+        $b = ord($data{0});
+        $data = substr($data, 1);
+        $extLen++;
+
+        switch($b) {
+        case 0xF9: // Graphic Control
+            $b = ord($data{1});
+            $this->m_disp   = ($b & 0x1C) >> 2;
+            $this->m_bUser  = ($b & 0x02) ? true : false;
+            $this->m_bTrans = ($b & 0x01) ? true : false;
+            $this->m_nDelay = $this->w2i(substr($data, 2, 2));
+            $this->m_nTrans = ord($data{4});
+            break;
+
+        case 0xFE: // Comment
+            $this->m_lpComm = substr($data, 1, ord($data{0}));
+            break;
+
+        case 0x01: // Plain text
+            break;
+
+        case 0xFF: // Application
+            break;
+        }
+
+        // SKIP DEFAULT AS DEFS MAY CHANGE
+        $b = ord($data{0});
+        $data = substr($data, 1);
+        $extLen++;
+        while($b > 0) {
+            $data = substr($data, $b);
+            $extLen += $b;
+            $b    = ord($data{0});
+            $data = substr($data, 1);
+            $extLen++;
+        }
+        return true;
+    }
+
+
+    private function w2i($str) {
+        return ord(substr($str, 0, 1)) + (ord(substr($str, 1, 1)) << 8);
+    }
+
+
+    function deInterlace() {
+        $data = $this->m_data;
+
+        for($i = 0; $i < 4; $i++) {
+            switch($i) {
+            case 0:
+                $s = 8;
+                $y = 0;
+                break;
+
+            case 1:
+                $s = 8;
+                $y = 4;
+                break;
+
+            case 2:
+                $s = 4;
+                $y = 2;
+                break;
+
+            case 3:
+                $s = 2;
+                $y = 1;
+                break;
+            }
+
+            for(; $y < $this->m_gih->m_nHeight; $y += $s) {
+                $lne = substr($this->m_data, 0, $this->m_gih->m_nWidth);
+                $this->m_data = substr($this->m_data, $this->m_gih->m_nWidth);
+
+                $data =
+                    substr($data, 0, $y * $this->m_gih->m_nWidth) .
+                    $lne .
+                    substr($data, ($y + 1) * $this->m_gih->m_nWidth);
+            }
+        }
+
+        $this->m_data = $data;
+    }
+
+}
+
+
+
+class PWGIF {
+
+    public $m_gfh;
+    public $m_lpData;
+    public $m_img;
+    public $m_bLoaded;
+
+
+    // @Horst: added param $extended
+    //  - true = it also loads and parse Bitmapdata
+    //  - false = it only loads Headerdata
+    public function __construct($extended = false) {
+        $this->m_gfh     = new PWGIFFILEHEADER($extended);
+        $this->m_img     = new PWGIFIMAGE($extended);
+        $this->m_lpData  = '';
+        $this->m_bLoaded = false;
+    }
+
+
+    public function loadFile($lpszFileName, $iIndex) {
+        if($iIndex < 0) {
+            return false;
+        }
+
+        // READ FILE
+        if(!($fh = @fopen($lpszFileName, 'rb'))) {
+            return false;
+        }
+        $this->m_lpData = @fRead($fh, @fileSize($lpszFileName));
+        fclose($fh);
+
+        // GET FILE HEADER
+        $len = 0;
+        if(!$this->m_gfh->load($this->m_lpData, $len)) {
+            return false;
+        }
+        $this->m_lpData = substr($this->m_lpData, $len);
+
+        do {
+        	$imgLen = 0;
+            if(!$this->m_img->load($this->m_lpData, $imgLen)) {
+                return false;
+            }
+            $this->m_lpData = substr($this->m_lpData, $imgLen);
+        }
+        while($iIndex-- > 0);
+
+        $this->m_bLoaded = true;
+        return true;
+    }
+
+}
+

--- a/wire/modules/Image/ImageInspector/ImageInspectorPng.php
+++ b/wire/modules/Image/ImageInspector/ImageInspectorPng.php
@@ -1,0 +1,168 @@
+<?php namespace ProcessWire;
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// parsePng is a part of FPDF v1.81 - 2015-12-20
+// Author: Olivier PLATHEY
+// http://fpdf.org/
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software to use, copy, modify, distribute, sublicense, and/or sell
+// copies of the software, and to permit persons to whom the software is furnished
+// to do so.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED.
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// PNG Inspector 
+// original code from FPDF modified in April 2016 by Horst Nogajski
+// to be used for png image inspection in ProcessWire 3+ (http://processwire.com/)
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+
+class PWPNG {
+
+	public $info = array();
+	public $errors = array();
+	protected $extended;
+
+
+    public function __construct($extended = false) {
+    	$this->extended = $extended;
+    }
+
+
+    public function loadFile($lpszFileName) {
+        // READ FILE
+        if(!($fh = @fopen($lpszFileName, 'rb'))) {
+			$this->Error('Can\'t open image file: '.$file);
+            return false;
+        }
+		$ret = (false === $this->_parsepngstream($fh, basename($lpszFileName))) ? false : true;
+        fclose($fh);
+        return $ret;
+    }
+    
+    
+	protected function _parsepngstream($f, $file) {
+		// Check signature
+		if($this->_readstream($f, 8) != chr(137) . 'PNG' . chr(13) . chr(10) . chr(26) . chr(10)) {
+			$this->Error('Not a PNG file: '.$file);
+			return false;
+		}
+		// Read header chunk
+		$this->_readstream($f, 4);
+		if($this->_readstream($f, 4) != 'IHDR') {
+			$this->Error('Incorrect PNG file: '.$file);
+			return false;
+		}
+		$w = $this->_readint($f);
+		$h = $this->_readint($f);
+		$bpc = ord($this->_readstream($f, 1));
+		//if($bpc > 8) {
+		//	$this->Error('16-bit depth not supported: '.$file);
+		//}
+		$ct = ord($this->_readstream($f, 1));
+		if($ct == 0 || $ct == 4) {
+			$colspace = 'DeviceGray';
+		} else if($ct == 2 || $ct == 6) {
+			$colspace = 'DeviceRGB';
+		} else if($ct == 3) {
+			$colspace = 'Indexed';
+		} else {
+			$this->Error('Unknown color type: '.$file);
+		}
+		if(ord($this->_readstream($f, 1)) != 0) $this->Error('Unknown compression method: '.$file);
+		if(ord($this->_readstream($f, 1)) != 0) $this->Error('Unknown filter method: '.$file);
+		$interlaced = ord($this->_readstream($f, 1)) != 0 ? true : false;
+		$this->_readstream($f, 4);
+		$dp = '/Predictor 15 /Colors '.($colspace=='DeviceRGB' ? 3 : 1).' /BitsPerComponent '.$bpc.' /Columns '.$w;
+
+		// Scan chunks looking for palette, transparency and image data
+		// http://www.w3.org/TR/2003/REC-PNG-20031110/#table53
+		// http://www.libpng.org/pub/png/book/chapter11.html#png.ch11.div.6
+		$pal = '';
+		$trns = '';
+		$counter = 0;
+		do {
+			$n = $this->_readint($f);
+			$counter += $n;
+			$type = $this->_readstream($f,4);
+			
+			if($type=='PLTE') {
+				
+				// Read palette
+				$pal = $this->_readstream($f, $n);
+				$this->_readstream($f,4);
+				
+			} else if($type == 'tRNS') {
+				
+				// Read transparency info
+				$t = $this->_readstream($f,$n);
+				if($ct == 0) {
+					$trns = array(ord(substr($t,1,1)));
+				} else if($ct == 2) {
+					$trns = array(ord(substr($t, 1, 1)), ord(substr($t, 3, 1)), ord(substr($t, 5, 1)));
+				} else {
+					$pos = strpos($t, chr(0));
+					if($pos !== false) $trns = array($pos);
+				}
+				$this->_readstream($f, 4);
+				
+			} else if($type == 'IEND' || $type == 'IDAT' || $counter >= 2048) {
+				
+				break;
+				
+			} else {
+				
+				$this->_readstream($f,$n+4);
+			}
+
+		} while($n);
+
+		if($colspace == 'Indexed' && empty($pal)) $this->Error('Missing palette in '.$file);
+		
+		$this->info = array(
+			'width' => $w,
+			'height' => $h,
+			'colspace' => $colspace,
+			'channels' => $ct,
+			'bits' => $bpc,
+			'dp' => $dp,
+			'palette' => utf8_encode($pal),
+			'trans' => $trns,
+			'alpha' => $ct >= 4 ? true : false,
+			'interlace' => $interlaced,
+			'errors' => $this->errors
+		);
+		
+		return true;
+	}
+
+	
+	protected function _readstream($f, $n) {
+		// Read n bytes from stream
+		$res = '';
+		while($n > 0 && !feof($f)) {
+			$s = fread($f, $n);
+			if($s === false) {
+				$this->Error('Error while reading stream');
+				return;
+			}
+			$n -= strlen($s);
+			$res .= $s;
+		}
+		if($n > 0) $this->Error('Unexpected end of stream');
+		return $res;
+	}
+
+	protected function _readint($f) {
+		// Read a 4-byte integer from stream
+		$a = unpack('Ni',$this->_readstream($f,4));
+		return $a['i'];
+	}
+    
+    
+    protected function Error($msg) {
+		$this->errors[] = $msg;
+    }
+    
+}

--- a/wire/modules/Image/ImageInspector/ImageInspectorPng.php
+++ b/wire/modules/Image/ImageInspector/ImageInspectorPng.php
@@ -25,23 +25,23 @@ class PWPNG {
 	protected $extended;
 
 
-    public function __construct($extended = false) {
-    	$this->extended = $extended;
-    }
+	public function __construct($extended = false) {
+		$this->extended = $extended;
+	}
 
 
-    public function loadFile($lpszFileName) {
-        // READ FILE
-        if(!($fh = @fopen($lpszFileName, 'rb'))) {
+	public function loadFile($lpszFileName) {
+		// READ FILE
+		if(!($fh = @fopen($lpszFileName, 'rb'))) {
 			$this->Error('Can\'t open image file: '.$file);
-            return false;
-        }
+			return false;
+		}
 		$ret = (false === $this->_parsepngstream($fh, basename($lpszFileName))) ? false : true;
-        fclose($fh);
-        return $ret;
-    }
-    
-    
+		fclose($fh);
+		return $ret;
+	}
+
+
 	protected function _parsepngstream($f, $file) {
 		// Check signature
 		if($this->_readstream($f, 8) != chr(137) . 'PNG' . chr(13) . chr(10) . chr(26) . chr(10)) {
@@ -159,10 +159,10 @@ class PWPNG {
 		$a = unpack('Ni',$this->_readstream($f,4));
 		return $a['i'];
 	}
-    
-    
-    protected function Error($msg) {
+
+
+	protected function Error($msg) {
 		$this->errors[] = $msg;
-    }
-    
+	}
+	
 }

--- a/wire/modules/ImageSizerEngineIMagick.module
+++ b/wire/modules/ImageSizerEngineIMagick.module
@@ -117,18 +117,32 @@ class ImageSizerEngineIMagick extends ImageSizerEngine {
 	 * @return bool
 	 * 
 	 */
-	public function supported($action = '') {
+	public function supported($action = 'imageformat') {
+
+		// first we check parts that are mandatory for all $actions
 		if(!class_exists("\\IMagick")) return false;
-		if($action == 'install') return true;
-		// compare current imagefile infos fetched from ImageInspector
-		$requested = $this->getImageInfo(false);
-		switch($requested) {
-			case 'jpg':
+
+		// and if it passes the mandatory requirements, we check particularly aspects here
+		switch($action) {
+			
+			case 'imageformat':
+				// compare current imagefile infos fetched from ImageInspector
+				$requested = $this->getImageInfo(false);
+				switch($requested) {
+					case 'jpg':
+						return true;
+					case 'png24':
+					case 'png24-trans':
+					case 'png24-alpha':
+						return true;
+					default:
+						return false;
+				}
+				break;
+			
+			case 'install':
 				return true;
-			case 'png24':
-			case 'png24-trans':
-			case 'png24-alpha':
-				return true;
+
 			default:
 				return false;
 		}

--- a/wire/modules/ImageSizerEngineIMagick.module
+++ b/wire/modules/ImageSizerEngineIMagick.module
@@ -111,7 +111,7 @@ class ImageSizerEngineIMagick extends ImageSizerEngine {
 	}
 
 	/**
-	 * Is IMagick supported?
+	 * Is IMagick supported? Is the current image(sub)format supported?
 	 * 
 	 * @param string $action
 	 * @return bool
@@ -120,12 +120,20 @@ class ImageSizerEngineIMagick extends ImageSizerEngine {
 	public function supported($action = '') {
 		if(!class_exists("\\IMagick")) return false;
 		if($action == 'install') return true;
-		$filename = $this->getFilename();
-		if($filename) {
-			$exts = array('jpg', 'jpeg', 'png');
-			if(!in_array(strtolower(pathinfo($filename, \PATHINFO_EXTENSION)), $exts)) return false;
+		// compare current imagefile infos fetched from ImageInspector
+		$requested = $this->getImageInfo(false);
+my_var_dump($requested, 1);
+
+		switch($requested) {
+			case 'jpg':
+				return true;
+			case 'png24':
+			case 'png24-trans':
+			case 'png24-alpha':
+				return true;
+			default:
+				return false;
 		}
-		return true;
 	}
 
 	/**

--- a/wire/modules/ImageSizerEngineIMagick.module
+++ b/wire/modules/ImageSizerEngineIMagick.module
@@ -122,8 +122,6 @@ class ImageSizerEngineIMagick extends ImageSizerEngine {
 		if($action == 'install') return true;
 		// compare current imagefile infos fetched from ImageInspector
 		$requested = $this->getImageInfo(false);
-my_var_dump($requested, 1);
-
 		switch($requested) {
 			case 'jpg':
 				return true;


### PR DESCRIPTION
a centralized, independent, early invoked Image Inspector for ImageSizer and the ImageSizerEngines.


This is useful for the ImageSizer and the ImageSizerEngines. PW now can detect all sorts of Imageformats and subformats. If we also implement a mandatory static feature list into ImageEngines, we can detect / select the ImageSizerEngine directly, without possibly load one that are not supports a given subformat. What (before ImageInspector) leads into (re)loading the image into the next Engine.

@ryancramerdesign : I have implemented it to the state that the images gets inspected early in the constructor of the ImageSizer and its result is available in ImageSizer via the new method "getImageInfo()". It is also available in the Imagesizer Engines too.

Next step would be to add a feature list to the engines, containing what type of subformats they support:
- gif, gif-trans, gif-anim, gif-anim-trans,
- png24, png24-trans, png8, png8-trans
- jpg

This adds a better performance for direct selection of the best engine and it frees the engines of doing its own detection, as we provide all needed information already!
