### PR TITLE
Fix for UTF-8 non-breaking space character

### DIFF
--- a/wire/modules/Inputfield/InputfieldCKEditor/InputfieldCKEditor.module
+++ b/wire/modules/Inputfield/InputfieldCKEditor/InputfieldCKEditor.module
@@ -481,9 +481,9 @@ class InputfieldCKEditor extends InputfieldTextarea {
 				}
 			}
 	
-			// remove gratitutious whitespace added by CKEditor
+			// remove gratuitous whitespace added by CKEditor
 			if(in_array(self::toggleCleanP, $toggles)) {
-				$value = str_replace(array('<p><br /></p>', '<p>&nbsp;</p>', '<p></p>', '<p> </p>'), '', $value); 
+				$value = str_replace(array('<p><br /></p>', '<p>&nbsp;</p>', "<p>\xc2\xa0</p>", '<p></p>', '<p> </p>'), '', $value);
 			}
 	
 			// convert non-breaking space to regular space


### PR DESCRIPTION
If "Use HTML Purifier" option is selected then $value has previously
passed through HTML Purifier where nbsp; is replaced with a UTF-8
non-breaking space character. Therefore this character needs to be added
to the array of replaced empty paragraph strings. Also fixed a typo in
the code comment :-)