### PR TITLE
InputfieldImage: extend input focus behaviour for textarea

### DIFF
--- a/wire/modules/Inputfield/InputfieldImage/InputfieldImage.js
+++ b/wire/modules/Inputfield/InputfieldImage/InputfieldImage.js
@@ -503,8 +503,8 @@ function InputfieldImage($) {
 			if($el.closest(".InputfieldImageEdit").length) {
 				closeEdit(null, $el.parents(".gridImages"));
 				
-			} else if($el.is("input") && $el.closest(".InputfieldImageEditAll").length) {
-				// clicked input in "edit all" mode, disable sortable, focus it then assign a blur event
+			} else if($el.is("input, textarea“) && $el.closest(".InputfieldImageEditAll").length) {
+				// clicked input/textarea in "edit all" mode, disable sortable, focus it then assign a blur event
 				$el.focus().one('blur', function() {
 					$el.closest('.gridImages').sortable('enable'); // re-enable sortable on blur
 				});


### PR DESCRIPTION
If the **number of rows for the description field** of an image in field settings is set to more than one a textarea will be displayed instead of an input.
 
At the moment it behaves like the following: if a user clicked on an input field in "edit all" mode, sortable would be disabled and if focussed the clicked input would get a blur event assigned. But this works only for inputs. This pull request extends this behaviour for textareas as well.

*Initial use case:* Regarding module ImageExtra I want to additionally allow the use of textareas for metadata (to be able to allow text formatters e.g. markdown parser).

Thanks in advance.