### PR TITLE
added char " ã " to the default list

### DIFF
--- a/wire/modules/Inputfield/InputfieldPageName/InputfieldPageName.module
+++ b/wire/modules/Inputfield/InputfieldPageName/InputfieldPageName.module
@@ -28,7 +28,8 @@ class InputfieldPageName extends InputfieldName implements ConfigurableModule {
 
 	public static $defaultReplacements = array(
 		'æ' => 'ae',
-		'å' => 'a', 
+		'å' => 'a',
+		'ã' => 'a',
 		'ä' => 'a',  
 		'ß' => 'ss', 
 		'ö' => 'o',  


### PR DESCRIPTION
It comes from a todays forums post: https://processwire.com/talk/topic/13444-loosing-a-character-in-automatic-page-name-bug/
As it wasn't in 'til know, we can set it like this, I think. :)