### PR TITLE
make render methods hookable

### DIFF
--- a/wire/modules/Fieldtype/FieldtypeComments/CommentList.php
+++ b/wire/modules/Fieldtype/FieldtypeComments/CommentList.php
@@ -127,7 +127,7 @@ class CommentList extends Wire implements CommentListInterface {
 		return $out;
 	}
 	
-	protected function renderList($parent_id = 0, $depth = 0) {
+	protected function ___renderList($parent_id = 0, $depth = 0) {
 		$out = $parent_id ? '' : $this->renderCheckActions();
 		$comments = $this->options['depth'] > 0 ? $this->getReplies($parent_id) : $this->comments;
 		if(!count($comments)) return $out;
@@ -155,7 +155,7 @@ class CommentList extends Wire implements CommentListInterface {
 	 * @return string 
 	 *
 	 */
-	public function renderItem(Comment $comment, $depth = 0) {
+	public function ___renderItem(Comment $comment, $depth = 0) {
 
 		$text = $comment->getFormatted('text'); 
 		$cite = $comment->getFormatted('cite'); 
@@ -224,7 +224,7 @@ class CommentList extends Wire implements CommentListInterface {
 		return $out; 	
 	}
 	
-	public function renderVotes(Comment $comment) {
+	public function ___renderVotes(Comment $comment) {
 		
 		if(!$this->options['useVotes']) return '';
 		
@@ -249,7 +249,7 @@ class CommentList extends Wire implements CommentListInterface {
 		return $out; 
 	}
 	
-	public function renderStars(Comment $comment) {
+	public function ___renderStars(Comment $comment) {
 		if(!$this->options['useStars']) return '';
 		if(!$comment->stars) return '';
 		$commentStars = new CommentStars();


### PR DESCRIPTION
Please make render methods hookable.
See [this issue](https://github.com/ryancramerdesign/ProcessWire/issues/1958) and [this forum thread](https://processwire.com/talk/topic/10790-custom-comment-output-best-practice/)
