### PR TITLE
changing charset configuration in all templates to simpler equivalent…

### DIFF
--- a/site-beginner/templates/_head.php
+++ b/site-beginner/templates/_head.php
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+	<meta charset="utf-8" />
 	<meta name="viewport" content="width=device-width, initial-scale=1" />
 	<title><?php echo $page->title; ?></title>
 	<meta name="description" content="<?php echo $page->summary; ?>" />

--- a/site-blank/templates/basic-page.php
+++ b/site-blank/templates/basic-page.php
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 	<head>
-		<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+		<meta charset="utf-8" />
 		<title><?php echo $page->title; ?></title>
 		<link rel="stylesheet" type="text/css" href="<?php echo $config->urls->templates?>styles/main.css" />
 	</head>

--- a/site-classic/templates/head.inc
+++ b/site-classic/templates/head.inc
@@ -13,7 +13,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+	<meta charset="utf-8" />
 
 	<title><?php echo $page->get("headline|title"); ?></title>
 

--- a/site-default/templates/_main.php
+++ b/site-default/templates/_main.php
@@ -32,7 +32,7 @@
 ?><!DOCTYPE html>
 <html lang="en">
 <head>
-	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+	<meta charset="utf-8" />
 	<meta name="viewport" content="width=device-width, initial-scale=1" />
 	<title><?php echo $title; ?></title>
 	<meta name="description" content="<?php echo $page->summary; ?>" />

--- a/site-languages/templates/_main.php
+++ b/site-languages/templates/_main.php
@@ -33,7 +33,7 @@
 ?><!DOCTYPE html>
 <html lang="<?php echo _x('en', 'HTML language code'); ?>">
 <head>
-	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+	<meta charset="utf-8" />
 	<meta name="viewport" content="width=device-width, initial-scale=1" />
 	<title><?php echo $title; ?></title>
 	<meta name="description" content="<?php echo $page->summary; ?>" />

--- a/wire/modules/AdminTheme/AdminThemeDefault/default.php
+++ b/wire/modules/AdminTheme/AdminThemeDefault/default.php
@@ -33,7 +33,7 @@ $extras = $adminTheme->getExtraMarkup();
 <html lang="<?php echo $helpers->_('en'); 
 	/* this intentionally on a separate line */ ?>">
 <head>
-	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+	<meta charset="utf-8" />
 	<meta name="robots" content="noindex, nofollow" />
 	<meta name="google" content="notranslate" />
 	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">

--- a/wire/modules/AdminTheme/AdminThemeDefault/install-head.inc
+++ b/wire/modules/AdminTheme/AdminThemeDefault/install-head.inc
@@ -5,7 +5,7 @@ if(!isset($formAction)) $formAction = './install.php';
 ?><!DOCTYPE html>
 <html lang="en"> 
 <head>
-	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+	<meta charset="utf-8" />
 	<meta name="robots" content="noindex, nofollow" />
 	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/wire/modules/AdminTheme/AdminThemeReno/default.php
+++ b/wire/modules/AdminTheme/AdminThemeReno/default.php
@@ -45,7 +45,7 @@ $extras = $adminTheme->getExtraMarkup();
 <html class="<?php echo $helpers->renderBodyClass(); ?>" lang="<?php echo $helpers->_('en'); 
 	/* this intentionally on a separate line */ ?>">
 <head>
-	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+	<meta charset="utf-8" />
 	<meta name="robots" content="noindex, nofollow" />
 	<meta name="google" content="notranslate" />
 	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">

--- a/wire/modules/Markup/MarkupHTMLPurifier/htmlpurifier/HTMLPurifier.standalone.php
+++ b/wire/modules/Markup/MarkupHTMLPurifier/htmlpurifier/HTMLPurifier.standalone.php
@@ -18817,7 +18817,7 @@ class HTMLPurifier_Lexer_DOMLex extends HTMLPurifier_Lexer
         }
 
         $ret .= '<html><head>';
-        $ret .= '<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />';
+        $ret .= '<meta charset="utf-8" />';
         // No protection if $html contains a stray </div>!
         $ret .= '</head><body>' . $html . '</body></html>';
         return $ret;

--- a/wire/templates-admin/default.php
+++ b/wire/templates-admin/default.php
@@ -57,7 +57,7 @@ if(!$browserTitle) $browserTitle = __(strip_tags($page->get('title|name')), __FI
 <html lang="<?php echo __('en', __FILE__); // HTML tag lang attribute
 	/* this intentionally on a separate line */ ?>"> 
 <head>
-	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+	<meta charset="utf-8" />
 	<meta name="robots" content="noindex, nofollow" />
 	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">


### PR DESCRIPTION
… in devns branch
According to the W3C the previous line does exactly the same as this new, more readable, line.
https://www.w3.org/International/questions/qa-html-encoding-declarations

Sorry, I don't know why "wire/modules/Markup/MarkupHTMLPurifier/htmlpurifier/HTMLPurifier.standalone.php" shows so many changes, while I changed just one line. Maybe you can exclude this while merging?